### PR TITLE
chore(ruby): change required ruby version from 3.0.0 to 2.7.8

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -107,6 +107,7 @@ GEM
       hashdiff (>= 0.4.0, < 2.0.0)
 
 PLATFORMS
+  ruby
   x86_64-linux
 
 DEPENDENCIES

--- a/chargify_wrapper.gemspec
+++ b/chargify_wrapper.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
 
   spec.summary = "Chargify API wrapper for internal use"
   spec.homepage = "https://github.com/blinkbid/chargify_wrapper"
-  spec.required_ruby_version = ">= 3.0.0"
+  spec.required_ruby_version = ">= 2.7.8"
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "https://github.com/blinkbid/chargify_wrapper"


### PR DESCRIPTION
N/A

### Feature

Set minimum ruby version to 2.7.8 in order to make it more compatible

### Setup

- Have SUBDOMAIN and API_KEY vars configured
- Install ruby 2.7.8 in your machine
- Run `bundle install`

### Q & A

Run specs locally with
```
bundle exec rspec
```

Run rubocop
```
bundle exec rubocop
```

Everything should pass