### PR TITLE
feat(price-points): Get all product price points created on Chargify site

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,6 +4,7 @@ PATH
     chargify_wrapper (0.3.0)
       activeresource (~> 6.0)
       activesupport (~> 7.0)
+      httplog (~> 1.6.3)
 
 GEM
   remote: https://rubygems.org/
@@ -33,6 +34,9 @@ GEM
     diff-lcs (1.5.0)
     dotenv (2.8.1)
     hashdiff (1.0.1)
+    httplog (1.6.3)
+      rack (>= 2.0)
+      rainbow (>= 2.0.0)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
     json (2.6.3)
@@ -45,6 +49,7 @@ GEM
       racc
     public_suffix (5.0.3)
     racc (1.7.1)
+    rack (3.0.11)
     rainbow (3.1.1)
     rake (13.0.6)
     regexp_parser (2.8.1)

--- a/README.md
+++ b/README.md
@@ -1,18 +1,53 @@
 # ChargifyWrapper
 
-**TODO: Improve README**
+## Requirements
 
-## Bundle gem
+Ruby 3.1.3
 
-```
-gem build chargify_wrapper.gemspec
-```
-
-## Gem setup
+## Usage
 
 ```ruby
 ChargifyWrapper.configure do |config|
   config.subdomain = 'your-local-subdomain'
   config.api_key = 'your-local-api-key'
+  config.log_requests = true # default is false
 end
+```
+After setting up those values, you can perform actions using the `Chargify::Wrapper` module as prefix.
+
+## Development
+
+Run bundle install
+```
+bundle install
+```
+### Use gem locally
+
+1. Uninstall previous versions
+```
+gem uninstall --force chargify_wrapper
+```
+
+2. Build gem from gemspec
+```
+gem build chargify_wrapper.gemspec --ouput=chargify_wrapper.gem
+```
+
+3. Install gem locally
+```
+gem install chargify_wrapper --local chargify_wrapper.gem
+```
+
+You can now use the gem as any other inside a ruby script or `irb`.
+
+> [!NOTE]
+> When developing new features, some classes might not be regonized even after
+> rebuilding the gem, specially in the case where a new class is created.
+> To fix that, add the new class to git using `git add PATH_TO_NEW_CLASS.rb` and
+> rebuild the gem.
+
+## Running specs
+
+```
+rake spec
 ```

--- a/chargify_wrapper.gemspec
+++ b/chargify_wrapper.gemspec
@@ -33,6 +33,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency("standard", "~> 1.25")
   spec.add_development_dependency("rubocop-performance", "~> 1.18")
   spec.add_development_dependency("rubocop-rspec", "~> 2.23")
+  spec.add_runtime_dependency("httplog", "~> 1.6.3")
   spec.add_runtime_dependency("activesupport", "~> 7.0")
   spec.add_runtime_dependency("activeresource", "~> 6.0")
 end

--- a/lib/chargify_wrapper.rb
+++ b/lib/chargify_wrapper.rb
@@ -1,9 +1,8 @@
 # frozen_string_literal: true
 
-require "active_support"
-require "active_support/time"
 require "active_resource"
+require "chargify_wrapper/resources/base"
+require "chargify_wrapper/resources/products_price_point"
+require "chargify_wrapper/resources/subscription"
 require "chargify_wrapper/config"
 require "chargify_wrapper/version"
-require "chargify_wrapper/resources/base"
-require "chargify_wrapper/resources/subscription"

--- a/lib/chargify_wrapper/config.rb
+++ b/lib/chargify_wrapper/config.rb
@@ -2,16 +2,18 @@
 
 require "active_support"
 require "active_support/time"
+require "httplog"
 
 module ChargifyWrapper
   class << self
-    attr_accessor :subdomain, :api_key
+    attr_accessor :subdomain, :api_key, :log_requests
 
     def configure
       yield self
 
       self.subdomain = subdomain || "test"
       self.api_key = api_key
+      self.log_requests = log_requests || false
 
       Base.site = "https://#{subdomain}.chargify.com"
       Base.user = api_key
@@ -27,6 +29,11 @@ module ChargifyWrapper
       Time.zone = "UTC"
       ActiveSupport::JSON::Encoding.use_standard_json_time_format = true
       ActiveSupport.parse_json_times = true
+
+      HttpLog.configure do |config|
+        config.enabled = log_requests
+        config.log_response = false
+      end
     end
   end
 end

--- a/lib/chargify_wrapper/config.rb
+++ b/lib/chargify_wrapper/config.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require "active_support"
+require "active_support/time"
+
 module ChargifyWrapper
   class << self
     attr_accessor :subdomain, :api_key

--- a/lib/chargify_wrapper/resources/products_price_point.rb
+++ b/lib/chargify_wrapper/resources/products_price_point.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+module ChargifyWrapper
+  class ProductsPricePoint < Base
+  end
+end


### PR DESCRIPTION
[BB-1154](https://87labs.atlassian.net/browse/BB-1154)
[New paywall](https://www.pivotaltracker.com/story/show/187042298)

### Feature

Add the ability to make get requests to the endpoint `/products_price_points.json` on chargify, as described [by the docs](https://developers.maxio.com/docs/api-docs/0f39276229ce7-list-all-products-price-points)

This endpoint will be used inside the app to get only the default price points of products, without having to get the entire product.

Also, this PR includes more info on README and the ability to log requests made to chargify to improve debugging

### Setup

Install the gem on your local env
```bash
gem uninstall --force chargify_wrapper
gem build chargify_wrapper.gemspec --ouput=chargify_wrapper.gem
gem install chargify_wrapper --local chargify_wrapper.gem
```

### Q & A

Open an `irb` console
Require the gem and configure it
```ruby
require 'chargify_wrapper'

ChargifyWrapper.configure do |config|
  config.subdomain = SUBDOMAIN
  config.api_key = API_KEY
  config.log_requests = true
end
```

With the gem configured, call the products price point class to get all price points
```ruby
ChargifyWrapper::ProductsPricePoint.all
```
It should return all price points created in your chargify subdomain

You should also be able to filter the results as the docs say, using `.where(filter: { ... })`