### PR TITLE
feat(payment-profile): creates payment_profile class

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ gem uninstall --force chargify_wrapper
 
 2. Build gem from gemspec
 ```
-gem build chargify_wrapper.gemspec --ouput=chargify_wrapper.gem
+gem build chargify_wrapper.gemspec --output=chargify_wrapper.gem
 ```
 
 3. Install gem locally

--- a/lib/chargify_wrapper.rb
+++ b/lib/chargify_wrapper.rb
@@ -3,5 +3,6 @@
 require "active_resource"
 require "chargify_wrapper/resources/base"
 require "chargify_wrapper/resources/subscription"
+require "chargify_wrapper/resources/payment_profile"
 require "chargify_wrapper/config"
 require "chargify_wrapper/version"

--- a/lib/chargify_wrapper/resources/payment_profile.rb
+++ b/lib/chargify_wrapper/resources/payment_profile.rb
@@ -1,0 +1,9 @@
+module ChargifyWrapper
+  class PaymentProfile < Base
+    belongs_to :subscription
+
+    def change_payment_profile
+      post(:change_payment_profile)
+    end
+  end
+end

--- a/lib/chargify_wrapper/resources/payment_profile.rb
+++ b/lib/chargify_wrapper/resources/payment_profile.rb
@@ -1,5 +1,4 @@
 module ChargifyWrapper
   class PaymentProfile < Base
-    belongs_to :subscription
   end
 end

--- a/lib/chargify_wrapper/resources/payment_profile.rb
+++ b/lib/chargify_wrapper/resources/payment_profile.rb
@@ -1,9 +1,5 @@
 module ChargifyWrapper
   class PaymentProfile < Base
     belongs_to :subscription
-
-    def change_payment_profile
-      post(:change_payment_profile)
-    end
   end
 end

--- a/lib/chargify_wrapper/resources/subscription.rb
+++ b/lib/chargify_wrapper/resources/subscription.rb
@@ -14,8 +14,8 @@ module ChargifyWrapper
       )
     end
 
-    def change_default_payment_profile(params = {})
-      payment_profiles.find(:one, params).change_payment_profile
+    def change_default_payment_profile(payment_profile)
+      post("payment_profiles/#{payment_profile.id}/change_payment_profile")
     end
   end
 end

--- a/lib/chargify_wrapper/resources/subscription.rb
+++ b/lib/chargify_wrapper/resources/subscription.rb
@@ -2,8 +2,6 @@
 
 module ChargifyWrapper
   class Subscription < Base
-    has_many :payment_profiles
-
     def delayed_cancel(attrs = {})
       post(
         :delayed_cancel, nil,

--- a/lib/chargify_wrapper/resources/subscription.rb
+++ b/lib/chargify_wrapper/resources/subscription.rb
@@ -2,6 +2,8 @@
 
 module ChargifyWrapper
   class Subscription < Base
+    has_many :payment_profiles
+
     def delayed_cancel(attrs = {})
       post(
         :delayed_cancel, nil,
@@ -10,6 +12,10 @@ module ChargifyWrapper
           reason_code: attrs[:code]
         }.to_json(root: :subscription)
       )
+    end
+
+    def change_default_payment_profile(params = {})
+      payment_profiles.find(:one, params).change_payment_profile
     end
   end
 end

--- a/spec/fixtures/cassettes/chargify_wrapper/subscription_change_default_payment_profile/when_payment_profile_is_not_found_raises_an_active_resource/resource_not_found_error.yml
+++ b/spec/fixtures/cassettes/chargify_wrapper/subscription_change_default_payment_profile/when_payment_profile_is_not_found_raises_an_active_resource/resource_not_found_error.yml
@@ -1,0 +1,133 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://<CHARGIFY_SUBDOMAIN>.chargify.com/subscriptions/76354749.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - "<CHARGIFY_API_KEY>"
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private, no-store
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 17 Jun 2024 17:50:59 GMT
+      Etag:
+      - W/"a9e6ca4d9a98e7094194a087a59dd923"
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - nginx + Phusion Passenger(R)
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - Phusion Passenger(R) Enterprise
+      X-Request-Id:
+      - 7d939554-8d3e-4a74-a1d9-71b9e39e7193
+      X-Runtime:
+      - '0.198835'
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Length:
+      - '3845'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"subscription":{"id":76354749,"state":"trialing","trial_started_at":"2024-06-06T10:45:56-07:00","trial_ended_at":"2024-06-20T10:45:56-07:00","activated_at":null,"created_at":"2024-06-06T10:45:56-07:00","updated_at":"2024-06-17T10:50:56-07:00","expires_at":null,"balance_in_cents":0,"current_period_ends_at":"2024-06-20T10:45:56-07:00","next_assessment_at":"2024-06-20T10:45:56-07:00","canceled_at":null,"cancellation_message":null,"next_product_id":null,"next_product_handle":null,"cancel_at_end_of_period":false,"payment_collection_method":"automatic","snap_day":null,"cancellation_method":null,"current_period_started_at":"2024-06-06T10:45:56-07:00","previous_state":"trialing","signup_payment_id":1088601798,"signup_revenue":"0.00","delayed_cancel_at":null,"coupon_code":null,"total_revenue_in_cents":0,"product_price_in_cents":28800,"product_version_number":1,"payment_type":"credit_card","referral_code":null,"coupon_use_count":null,"coupon_uses_allowed":null,"reason_code":null,"automatically_resume_at":null,"coupon_codes":[],"offer_id":null,"payer_id":null,"receives_invoice_emails":null,"product_price_point_id":2245073,"next_product_price_point_id":null,"net_terms":null,"stored_credential_transaction_id":null,"reference":null,"currency":"USD","on_hold_at":null,"scheduled_cancellation_at":null,"product_price_point_type":"default","dunning_communication_delay_enabled":false,"dunning_communication_delay_time_zone":null,"current_billing_amount_in_cents":28800,"customer":{"id":80219272,"first_name":"Luana","last_name":"2","organization":null,"email":"ls2@gmail.com","created_at":"2024-06-06T10:45:56-07:00","updated_at":"2024-06-06T10:45:56-07:00","reference":null,"address":null,"address_2":null,"city":null,"state":null,"state_name":null,"zip":null,"country":null,"country_name":null,"phone":null,"portal_invite_last_sent_at":null,"portal_invite_last_accepted_at":null,"verified":false,"portal_customer_created_at":null,"vat_number":null,"cc_emails":null,"tax_exempt":false,"parent_id":null},"product":{"id":6388932,"name":"Solo-Annual-T","handle":"solo-annual-trial","description":"Users:
+        1\r\nPersonalities: 10","accounting_code":"11","request_credit_card":true,"expiration_interval":null,"expiration_interval_unit":"never","created_at":"2022-12-15T06:06:31-08:00","updated_at":"2022-12-15T06:06:31-08:00","price_in_cents":28800,"interval":12,"interval_unit":"month","initial_charge_in_cents":null,"trial_price_in_cents":0,"trial_interval":14,"trial_interval_unit":"day","archived_at":null,"require_credit_card":false,"return_params":"","taxable":false,"update_return_url":"","tax_code":"","initial_charge_after_trial":false,"version_number":1,"update_return_params":"","default_product_price_point_id":2245073,"request_billing_address":false,"require_billing_address":false,"require_shipping_address":false,"use_site_exchange_rate":true,"item_category":null,"product_price_point_id":2245073,"product_price_point_name":"New
+        Price May 2021","product_price_point_handle":"uuid:71f899e0-8c25-0139-8dc8-0a575a757c23","product_family":{"id":2473952,"name":"Blinkbid
+        - USA","description":"Blinkbid software sold in the United States, in USD
+        currency.","handle":"blinkbid-usa","accounting_code":null,"created_at":"2022-12-15T06:06:29-08:00","updated_at":"2022-12-15T06:06:29-08:00"},"public_signup_pages":[]},"credit_card":{"id":59640936,"first_name":"Joao","last_name":"Das
+        Neves","masked_card_number":"XXXX-XXXX-XXXX-3858","card_type":"visa","expiration_month":11,"expiration_year":2034,"customer_id":80219272,"current_vault":"bogus","vault_token":"1","billing_address":"123
+        Main St.","billing_city":"Boston","billing_state":"MA","billing_zip":"02120","billing_country":"US","customer_vault_token":null,"billing_address_2":"Addd2","payment_type":"credit_card","disabled":false,"site_gateway_setting_id":null,"gateway_handle":null}}}'
+  recorded_at: Mon, 17 Jun 2024 17:51:05 GMT
+- request:
+    method: post
+    uri: https://<CHARGIFY_SUBDOMAIN>.chargify.com/subscriptions/76354749/payment_profiles/12345678/change_payment_profile.json
+    body:
+      encoding: UTF-8
+      string: '{"subscription":{"id":76354749,"state":"trialing","trial_started_at":"2024-06-06T17:45:56.000Z","trial_ended_at":"2024-06-20T17:45:56.000Z","activated_at":null,"created_at":"2024-06-06T17:45:56.000Z","updated_at":"2024-06-17T17:50:56.000Z","expires_at":null,"balance_in_cents":0,"current_period_ends_at":"2024-06-20T17:45:56.000Z","next_assessment_at":"2024-06-20T17:45:56.000Z","canceled_at":null,"cancellation_message":null,"next_product_id":null,"next_product_handle":null,"cancel_at_end_of_period":false,"payment_collection_method":"automatic","snap_day":null,"cancellation_method":null,"current_period_started_at":"2024-06-06T17:45:56.000Z","previous_state":"trialing","signup_payment_id":1088601798,"signup_revenue":"0.00","delayed_cancel_at":null,"coupon_code":null,"total_revenue_in_cents":0,"product_price_in_cents":28800,"product_version_number":1,"payment_type":"credit_card","referral_code":null,"coupon_use_count":null,"coupon_uses_allowed":null,"reason_code":null,"automatically_resume_at":null,"coupon_codes":[],"offer_id":null,"payer_id":null,"receives_invoice_emails":null,"product_price_point_id":2245073,"next_product_price_point_id":null,"net_terms":null,"stored_credential_transaction_id":null,"reference":null,"currency":"USD","on_hold_at":null,"scheduled_cancellation_at":null,"product_price_point_type":"default","dunning_communication_delay_enabled":false,"dunning_communication_delay_time_zone":null,"current_billing_amount_in_cents":28800,"customer":{"id":80219272,"first_name":"Luana","last_name":"2","organization":null,"email":"ls2@gmail.com","created_at":"2024-06-06T17:45:56.000Z","updated_at":"2024-06-06T17:45:56.000Z","reference":null,"address":null,"address_2":null,"city":null,"state":null,"state_name":null,"zip":null,"country":null,"country_name":null,"phone":null,"portal_invite_last_sent_at":null,"portal_invite_last_accepted_at":null,"verified":false,"portal_customer_created_at":null,"vat_number":null,"cc_emails":null,"tax_exempt":false,"parent_id":null},"product":{"id":6388932,"name":"Solo-Annual-T","handle":"solo-annual-trial","description":"Users:
+        1\r\nPersonalities: 10","accounting_code":"11","request_credit_card":true,"expiration_interval":null,"expiration_interval_unit":"never","created_at":"2022-12-15T14:06:31.000Z","updated_at":"2022-12-15T14:06:31.000Z","price_in_cents":28800,"interval":12,"interval_unit":"month","initial_charge_in_cents":null,"trial_price_in_cents":0,"trial_interval":14,"trial_interval_unit":"day","archived_at":null,"require_credit_card":false,"return_params":"","taxable":false,"update_return_url":"","tax_code":"","initial_charge_after_trial":false,"version_number":1,"update_return_params":"","default_product_price_point_id":2245073,"request_billing_address":false,"require_billing_address":false,"require_shipping_address":false,"use_site_exchange_rate":true,"item_category":null,"product_price_point_id":2245073,"product_price_point_name":"New
+        Price May 2021","product_price_point_handle":"uuid:71f899e0-8c25-0139-8dc8-0a575a757c23","product_family":{"id":2473952,"name":"Blinkbid
+        - USA","description":"Blinkbid software sold in the United States, in USD
+        currency.","handle":"blinkbid-usa","accounting_code":null,"created_at":"2022-12-15T14:06:29.000Z","updated_at":"2022-12-15T14:06:29.000Z"},"public_signup_pages":[]},"credit_card":{"id":59640936,"first_name":"Joao","last_name":"Das
+        Neves","masked_card_number":"XXXX-XXXX-XXXX-3858","card_type":"visa","expiration_month":11,"expiration_year":2034,"customer_id":80219272,"current_vault":"bogus","vault_token":"1","billing_address":"123
+        Main St.","billing_city":"Boston","billing_state":"MA","billing_zip":"02120","billing_country":"US","customer_vault_token":null,"billing_address_2":"Addd2","payment_type":"credit_card","disabled":false,"site_gateway_setting_id":null,"gateway_handle":null}}}'
+    headers:
+      Authorization:
+      - "<CHARGIFY_API_KEY>"
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Cache-Control:
+      - private, no-store
+      Content-Type:
+      - text/html
+      Date:
+      - Mon, 17 Jun 2024 17:51:00 GMT
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - nginx + Phusion Passenger(R)
+      Status:
+      - 404 Not Found
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - Phusion Passenger(R) Enterprise
+      X-Request-Id:
+      - a57b6968-e674-4a81-bad6-c3910cb314c8
+      X-Runtime:
+      - '0.033019'
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Length:
+      - '0'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: ''
+  recorded_at: Mon, 17 Jun 2024 17:51:06 GMT
+recorded_with: VCR 6.2.0

--- a/spec/fixtures/cassettes/chargify_wrapper/subscription_change_default_payment_profile/when_payment_profile_is_valid_changes_the_default_payment_profile.yml
+++ b/spec/fixtures/cassettes/chargify_wrapper/subscription_change_default_payment_profile/when_payment_profile_is_valid_changes_the_default_payment_profile.yml
@@ -1,0 +1,206 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://<CHARGIFY_SUBDOMAIN>.chargify.com/subscriptions/76354749.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - "<CHARGIFY_API_KEY>"
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private, no-store
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 17 Jun 2024 17:50:54 GMT
+      Etag:
+      - W/"bda39ce8f3c8f417ecdb662613980824"
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - nginx + Phusion Passenger(R)
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - Phusion Passenger(R) Enterprise
+      X-Request-Id:
+      - c69733c8-523b-41f8-a330-0f047749f1a6
+      X-Runtime:
+      - '0.172731'
+      X-Xss-Protection:
+      - 1; mode=block
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"subscription":{"id":76354749,"state":"trialing","trial_started_at":"2024-06-06T10:45:56-07:00","trial_ended_at":"2024-06-20T10:45:56-07:00","activated_at":null,"created_at":"2024-06-06T10:45:56-07:00","updated_at":"2024-06-17T10:50:53-07:00","expires_at":null,"balance_in_cents":0,"current_period_ends_at":"2024-06-20T10:45:56-07:00","next_assessment_at":"2024-06-20T10:45:56-07:00","canceled_at":null,"cancellation_message":null,"next_product_id":null,"next_product_handle":null,"cancel_at_end_of_period":false,"payment_collection_method":"automatic","snap_day":null,"cancellation_method":null,"current_period_started_at":"2024-06-06T10:45:56-07:00","previous_state":"trialing","signup_payment_id":1088601798,"signup_revenue":"0.00","delayed_cancel_at":null,"coupon_code":null,"total_revenue_in_cents":0,"product_price_in_cents":28800,"product_version_number":1,"payment_type":"credit_card","referral_code":null,"coupon_use_count":null,"coupon_uses_allowed":null,"reason_code":null,"automatically_resume_at":null,"coupon_codes":[],"offer_id":null,"payer_id":null,"receives_invoice_emails":null,"product_price_point_id":2245073,"next_product_price_point_id":null,"net_terms":null,"stored_credential_transaction_id":null,"reference":null,"currency":"USD","on_hold_at":null,"scheduled_cancellation_at":null,"product_price_point_type":"default","dunning_communication_delay_enabled":false,"dunning_communication_delay_time_zone":null,"current_billing_amount_in_cents":28800,"customer":{"id":80219272,"first_name":"Luana","last_name":"2","organization":null,"email":"ls2@gmail.com","created_at":"2024-06-06T10:45:56-07:00","updated_at":"2024-06-06T10:45:56-07:00","reference":null,"address":null,"address_2":null,"city":null,"state":null,"state_name":null,"zip":null,"country":null,"country_name":null,"phone":null,"portal_invite_last_sent_at":null,"portal_invite_last_accepted_at":null,"verified":false,"portal_customer_created_at":null,"vat_number":null,"cc_emails":null,"tax_exempt":false,"parent_id":null},"product":{"id":6388932,"name":"Solo-Annual-T","handle":"solo-annual-trial","description":"Users:
+        1\r\nPersonalities: 10","accounting_code":"11","request_credit_card":true,"expiration_interval":null,"expiration_interval_unit":"never","created_at":"2022-12-15T06:06:31-08:00","updated_at":"2022-12-15T06:06:31-08:00","price_in_cents":28800,"interval":12,"interval_unit":"month","initial_charge_in_cents":null,"trial_price_in_cents":0,"trial_interval":14,"trial_interval_unit":"day","archived_at":null,"require_credit_card":false,"return_params":"","taxable":false,"update_return_url":"","tax_code":"","initial_charge_after_trial":false,"version_number":1,"update_return_params":"","default_product_price_point_id":2245073,"request_billing_address":false,"require_billing_address":false,"require_shipping_address":false,"use_site_exchange_rate":true,"item_category":null,"product_price_point_id":2245073,"product_price_point_name":"New
+        Price May 2021","product_price_point_handle":"uuid:71f899e0-8c25-0139-8dc8-0a575a757c23","product_family":{"id":2473952,"name":"Blinkbid
+        - USA","description":"Blinkbid software sold in the United States, in USD
+        currency.","handle":"blinkbid-usa","accounting_code":null,"created_at":"2022-12-15T06:06:29-08:00","updated_at":"2022-12-15T06:06:29-08:00"},"public_signup_pages":[]},"credit_card":{"id":59640935,"first_name":"Joao","last_name":"Das
+        Neves","masked_card_number":"XXXX-XXXX-XXXX-3858","card_type":"visa","expiration_month":11,"expiration_year":2034,"customer_id":80219272,"current_vault":"bogus","vault_token":"1","billing_address":"123
+        Main St.","billing_city":"Boston","billing_state":"MA","billing_zip":"02120","billing_country":"US","customer_vault_token":null,"billing_address_2":"Addd2","payment_type":"credit_card","disabled":false,"site_gateway_setting_id":null,"gateway_handle":null}}}'
+  recorded_at: Mon, 17 Jun 2024 17:50:59 GMT
+- request:
+    method: post
+    uri: https://<CHARGIFY_SUBDOMAIN>.chargify.com/payment_profiles.json
+    body:
+      encoding: UTF-8
+      string: '{"payment_profile":{"first_name":"Joao","last_name":"Das Neves","last_four":"3858","card_type":"visa","expiration_month":11,"expiration_year":2034,"customer_id":80219272,"current_vault":"bogus","vault_token":"1","billing_address":"123
+        Main St.","billing_city":"Boston","billing_state":"MA","billing_zip":"02120","billing_country":"US","billing_address_2":"Addd2","payment_type":"credit_card"}}'
+    headers:
+      Authorization:
+      - "<CHARGIFY_API_KEY>"
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Cache-Control:
+      - private, no-store
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 17 Jun 2024 17:50:55 GMT
+      Etag:
+      - W/"8a2a0e0f797b0b1c80e270dedb231657"
+      Location:
+      - "/payment_profiles/59640936"
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - nginx + Phusion Passenger(R)
+      Status:
+      - 201 Created
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - Phusion Passenger(R) Enterprise
+      X-Request-Id:
+      - 7bb2abd5-5ed2-4c24-9c7a-5ba30fc060c7
+      X-Runtime:
+      - '0.046106'
+      X-Xss-Protection:
+      - 1; mode=block
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"payment_profile":{"id":59640936,"first_name":"Joao","last_name":"Das
+        Neves","masked_card_number":"XXXX-XXXX-XXXX-3858","card_type":"visa","expiration_month":11,"expiration_year":2034,"customer_id":80219272,"current_vault":"bogus","vault_token":"1","billing_address":"123
+        Main St.","billing_city":"Boston","billing_state":"MA","billing_zip":"02120","billing_country":"US","customer_vault_token":null,"billing_address_2":"Addd2","site_gateway_setting_id":null,"payment_type":"credit_card","disabled":false,"gateway_handle":null}}'
+  recorded_at: Mon, 17 Jun 2024 17:51:00 GMT
+- request:
+    method: post
+    uri: https://<CHARGIFY_SUBDOMAIN>.chargify.com/subscriptions/76354749/payment_profiles/59640936/change_payment_profile.json
+    body:
+      encoding: UTF-8
+      string: '{"subscription":{"id":76354749,"state":"trialing","trial_started_at":"2024-06-06T17:45:56.000Z","trial_ended_at":"2024-06-20T17:45:56.000Z","activated_at":null,"created_at":"2024-06-06T17:45:56.000Z","updated_at":"2024-06-17T17:50:53.000Z","expires_at":null,"balance_in_cents":0,"current_period_ends_at":"2024-06-20T17:45:56.000Z","next_assessment_at":"2024-06-20T17:45:56.000Z","canceled_at":null,"cancellation_message":null,"next_product_id":null,"next_product_handle":null,"cancel_at_end_of_period":false,"payment_collection_method":"automatic","snap_day":null,"cancellation_method":null,"current_period_started_at":"2024-06-06T17:45:56.000Z","previous_state":"trialing","signup_payment_id":1088601798,"signup_revenue":"0.00","delayed_cancel_at":null,"coupon_code":null,"total_revenue_in_cents":0,"product_price_in_cents":28800,"product_version_number":1,"payment_type":"credit_card","referral_code":null,"coupon_use_count":null,"coupon_uses_allowed":null,"reason_code":null,"automatically_resume_at":null,"coupon_codes":[],"offer_id":null,"payer_id":null,"receives_invoice_emails":null,"product_price_point_id":2245073,"next_product_price_point_id":null,"net_terms":null,"stored_credential_transaction_id":null,"reference":null,"currency":"USD","on_hold_at":null,"scheduled_cancellation_at":null,"product_price_point_type":"default","dunning_communication_delay_enabled":false,"dunning_communication_delay_time_zone":null,"current_billing_amount_in_cents":28800,"customer":{"id":80219272,"first_name":"Luana","last_name":"2","organization":null,"email":"ls2@gmail.com","created_at":"2024-06-06T17:45:56.000Z","updated_at":"2024-06-06T17:45:56.000Z","reference":null,"address":null,"address_2":null,"city":null,"state":null,"state_name":null,"zip":null,"country":null,"country_name":null,"phone":null,"portal_invite_last_sent_at":null,"portal_invite_last_accepted_at":null,"verified":false,"portal_customer_created_at":null,"vat_number":null,"cc_emails":null,"tax_exempt":false,"parent_id":null},"product":{"id":6388932,"name":"Solo-Annual-T","handle":"solo-annual-trial","description":"Users:
+        1\r\nPersonalities: 10","accounting_code":"11","request_credit_card":true,"expiration_interval":null,"expiration_interval_unit":"never","created_at":"2022-12-15T14:06:31.000Z","updated_at":"2022-12-15T14:06:31.000Z","price_in_cents":28800,"interval":12,"interval_unit":"month","initial_charge_in_cents":null,"trial_price_in_cents":0,"trial_interval":14,"trial_interval_unit":"day","archived_at":null,"require_credit_card":false,"return_params":"","taxable":false,"update_return_url":"","tax_code":"","initial_charge_after_trial":false,"version_number":1,"update_return_params":"","default_product_price_point_id":2245073,"request_billing_address":false,"require_billing_address":false,"require_shipping_address":false,"use_site_exchange_rate":true,"item_category":null,"product_price_point_id":2245073,"product_price_point_name":"New
+        Price May 2021","product_price_point_handle":"uuid:71f899e0-8c25-0139-8dc8-0a575a757c23","product_family":{"id":2473952,"name":"Blinkbid
+        - USA","description":"Blinkbid software sold in the United States, in USD
+        currency.","handle":"blinkbid-usa","accounting_code":null,"created_at":"2022-12-15T14:06:29.000Z","updated_at":"2022-12-15T14:06:29.000Z"},"public_signup_pages":[]},"credit_card":{"id":59640935,"first_name":"Joao","last_name":"Das
+        Neves","masked_card_number":"XXXX-XXXX-XXXX-3858","card_type":"visa","expiration_month":11,"expiration_year":2034,"customer_id":80219272,"current_vault":"bogus","vault_token":"1","billing_address":"123
+        Main St.","billing_city":"Boston","billing_state":"MA","billing_zip":"02120","billing_country":"US","customer_vault_token":null,"billing_address_2":"Addd2","payment_type":"credit_card","disabled":false,"site_gateway_setting_id":null,"gateway_handle":null}}}'
+    headers:
+      Authorization:
+      - "<CHARGIFY_API_KEY>"
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private, no-store
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 17 Jun 2024 17:50:56 GMT
+      Etag:
+      - W/"8a2a0e0f797b0b1c80e270dedb231657"
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - nginx + Phusion Passenger(R)
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - Phusion Passenger(R) Enterprise
+      X-Request-Id:
+      - 481ef0a5-7a1a-40f8-9fa1-c59f6445ced9
+      X-Runtime:
+      - '0.226875'
+      X-Xss-Protection:
+      - 1; mode=block
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"payment_profile":{"id":59640936,"first_name":"Joao","last_name":"Das
+        Neves","masked_card_number":"XXXX-XXXX-XXXX-3858","card_type":"visa","expiration_month":11,"expiration_year":2034,"customer_id":80219272,"current_vault":"bogus","vault_token":"1","billing_address":"123
+        Main St.","billing_city":"Boston","billing_state":"MA","billing_zip":"02120","billing_country":"US","customer_vault_token":null,"billing_address_2":"Addd2","site_gateway_setting_id":null,"payment_type":"credit_card","disabled":false,"gateway_handle":null}}'
+  recorded_at: Mon, 17 Jun 2024 17:51:01 GMT
+recorded_with: VCR 6.2.0

--- a/spec/fixtures/cassettes/chargify_wrapper/subscription_change_default_payment_profile/when_payment_profile_is_valid_returns_http_status_200.yml
+++ b/spec/fixtures/cassettes/chargify_wrapper/subscription_change_default_payment_profile/when_payment_profile_is_valid_returns_http_status_200.yml
@@ -1,0 +1,206 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://<CHARGIFY_SUBDOMAIN>.chargify.com/subscriptions/76354749.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - "<CHARGIFY_API_KEY>"
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private, no-store
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 17 Jun 2024 17:50:51 GMT
+      Etag:
+      - W/"1e177eb690cea9a9adc6e667924bfb05"
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - nginx + Phusion Passenger(R)
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - Phusion Passenger(R) Enterprise
+      X-Request-Id:
+      - c4faa21a-48e6-4134-ab6e-b98281cd444f
+      X-Runtime:
+      - '0.285429'
+      X-Xss-Protection:
+      - 1; mode=block
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"subscription":{"id":76354749,"state":"trialing","trial_started_at":"2024-06-06T10:45:56-07:00","trial_ended_at":"2024-06-20T10:45:56-07:00","activated_at":null,"created_at":"2024-06-06T10:45:56-07:00","updated_at":"2024-06-17T10:43:22-07:00","expires_at":null,"balance_in_cents":0,"current_period_ends_at":"2024-06-20T10:45:56-07:00","next_assessment_at":"2024-06-20T10:45:56-07:00","canceled_at":null,"cancellation_message":null,"next_product_id":null,"next_product_handle":null,"cancel_at_end_of_period":false,"payment_collection_method":"automatic","snap_day":null,"cancellation_method":null,"current_period_started_at":"2024-06-06T10:45:56-07:00","previous_state":"trialing","signup_payment_id":1088601798,"signup_revenue":"0.00","delayed_cancel_at":null,"coupon_code":null,"total_revenue_in_cents":0,"product_price_in_cents":28800,"product_version_number":1,"payment_type":"credit_card","referral_code":null,"coupon_use_count":null,"coupon_uses_allowed":null,"reason_code":null,"automatically_resume_at":null,"coupon_codes":[],"offer_id":null,"payer_id":null,"receives_invoice_emails":null,"product_price_point_id":2245073,"next_product_price_point_id":null,"net_terms":null,"stored_credential_transaction_id":null,"reference":null,"currency":"USD","on_hold_at":null,"scheduled_cancellation_at":null,"product_price_point_type":"default","dunning_communication_delay_enabled":false,"dunning_communication_delay_time_zone":null,"current_billing_amount_in_cents":28800,"customer":{"id":80219272,"first_name":"Luana","last_name":"2","organization":null,"email":"ls2@gmail.com","created_at":"2024-06-06T10:45:56-07:00","updated_at":"2024-06-06T10:45:56-07:00","reference":null,"address":null,"address_2":null,"city":null,"state":null,"state_name":null,"zip":null,"country":null,"country_name":null,"phone":null,"portal_invite_last_sent_at":null,"portal_invite_last_accepted_at":null,"verified":false,"portal_customer_created_at":null,"vat_number":null,"cc_emails":null,"tax_exempt":false,"parent_id":null},"product":{"id":6388932,"name":"Solo-Annual-T","handle":"solo-annual-trial","description":"Users:
+        1\r\nPersonalities: 10","accounting_code":"11","request_credit_card":true,"expiration_interval":null,"expiration_interval_unit":"never","created_at":"2022-12-15T06:06:31-08:00","updated_at":"2022-12-15T06:06:31-08:00","price_in_cents":28800,"interval":12,"interval_unit":"month","initial_charge_in_cents":null,"trial_price_in_cents":0,"trial_interval":14,"trial_interval_unit":"day","archived_at":null,"require_credit_card":false,"return_params":"","taxable":false,"update_return_url":"","tax_code":"","initial_charge_after_trial":false,"version_number":1,"update_return_params":"","default_product_price_point_id":2245073,"request_billing_address":false,"require_billing_address":false,"require_shipping_address":false,"use_site_exchange_rate":true,"item_category":null,"product_price_point_id":2245073,"product_price_point_name":"New
+        Price May 2021","product_price_point_handle":"uuid:71f899e0-8c25-0139-8dc8-0a575a757c23","product_family":{"id":2473952,"name":"Blinkbid
+        - USA","description":"Blinkbid software sold in the United States, in USD
+        currency.","handle":"blinkbid-usa","accounting_code":null,"created_at":"2022-12-15T06:06:29-08:00","updated_at":"2022-12-15T06:06:29-08:00"},"public_signup_pages":[]},"credit_card":{"id":59640806,"first_name":"Joao","last_name":"Das
+        Neves","masked_card_number":"XXXX-XXXX-XXXX-3858","card_type":"visa","expiration_month":11,"expiration_year":2034,"customer_id":80219272,"current_vault":"bogus","vault_token":"1","billing_address":"123
+        Main St.","billing_city":"Boston","billing_state":"MA","billing_zip":"02120","billing_country":"US","customer_vault_token":null,"billing_address_2":"Addd2","payment_type":"credit_card","disabled":false,"site_gateway_setting_id":null,"gateway_handle":null}}}'
+  recorded_at: Mon, 17 Jun 2024 17:50:56 GMT
+- request:
+    method: post
+    uri: https://<CHARGIFY_SUBDOMAIN>.chargify.com/payment_profiles.json
+    body:
+      encoding: UTF-8
+      string: '{"payment_profile":{"first_name":"Joao","last_name":"Das Neves","last_four":"3858","card_type":"visa","expiration_month":11,"expiration_year":2034,"customer_id":80219272,"current_vault":"bogus","vault_token":"1","billing_address":"123
+        Main St.","billing_city":"Boston","billing_state":"MA","billing_zip":"02120","billing_country":"US","billing_address_2":"Addd2","payment_type":"credit_card"}}'
+    headers:
+      Authorization:
+      - "<CHARGIFY_API_KEY>"
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Cache-Control:
+      - private, no-store
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 17 Jun 2024 17:50:52 GMT
+      Etag:
+      - W/"6edaef378beaed80e5cf15d7a3c273e0"
+      Location:
+      - "/payment_profiles/59640935"
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - nginx + Phusion Passenger(R)
+      Status:
+      - 201 Created
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - Phusion Passenger(R) Enterprise
+      X-Request-Id:
+      - c3a90f82-4b1e-4d96-afb8-05cdf95f2c69
+      X-Runtime:
+      - '0.044965'
+      X-Xss-Protection:
+      - 1; mode=block
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"payment_profile":{"id":59640935,"first_name":"Joao","last_name":"Das
+        Neves","masked_card_number":"XXXX-XXXX-XXXX-3858","card_type":"visa","expiration_month":11,"expiration_year":2034,"customer_id":80219272,"current_vault":"bogus","vault_token":"1","billing_address":"123
+        Main St.","billing_city":"Boston","billing_state":"MA","billing_zip":"02120","billing_country":"US","customer_vault_token":null,"billing_address_2":"Addd2","site_gateway_setting_id":null,"payment_type":"credit_card","disabled":false,"gateway_handle":null}}'
+  recorded_at: Mon, 17 Jun 2024 17:50:57 GMT
+- request:
+    method: post
+    uri: https://<CHARGIFY_SUBDOMAIN>.chargify.com/subscriptions/76354749/payment_profiles/59640935/change_payment_profile.json
+    body:
+      encoding: UTF-8
+      string: '{"subscription":{"id":76354749,"state":"trialing","trial_started_at":"2024-06-06T17:45:56.000Z","trial_ended_at":"2024-06-20T17:45:56.000Z","activated_at":null,"created_at":"2024-06-06T17:45:56.000Z","updated_at":"2024-06-17T17:43:22.000Z","expires_at":null,"balance_in_cents":0,"current_period_ends_at":"2024-06-20T17:45:56.000Z","next_assessment_at":"2024-06-20T17:45:56.000Z","canceled_at":null,"cancellation_message":null,"next_product_id":null,"next_product_handle":null,"cancel_at_end_of_period":false,"payment_collection_method":"automatic","snap_day":null,"cancellation_method":null,"current_period_started_at":"2024-06-06T17:45:56.000Z","previous_state":"trialing","signup_payment_id":1088601798,"signup_revenue":"0.00","delayed_cancel_at":null,"coupon_code":null,"total_revenue_in_cents":0,"product_price_in_cents":28800,"product_version_number":1,"payment_type":"credit_card","referral_code":null,"coupon_use_count":null,"coupon_uses_allowed":null,"reason_code":null,"automatically_resume_at":null,"coupon_codes":[],"offer_id":null,"payer_id":null,"receives_invoice_emails":null,"product_price_point_id":2245073,"next_product_price_point_id":null,"net_terms":null,"stored_credential_transaction_id":null,"reference":null,"currency":"USD","on_hold_at":null,"scheduled_cancellation_at":null,"product_price_point_type":"default","dunning_communication_delay_enabled":false,"dunning_communication_delay_time_zone":null,"current_billing_amount_in_cents":28800,"customer":{"id":80219272,"first_name":"Luana","last_name":"2","organization":null,"email":"ls2@gmail.com","created_at":"2024-06-06T17:45:56.000Z","updated_at":"2024-06-06T17:45:56.000Z","reference":null,"address":null,"address_2":null,"city":null,"state":null,"state_name":null,"zip":null,"country":null,"country_name":null,"phone":null,"portal_invite_last_sent_at":null,"portal_invite_last_accepted_at":null,"verified":false,"portal_customer_created_at":null,"vat_number":null,"cc_emails":null,"tax_exempt":false,"parent_id":null},"product":{"id":6388932,"name":"Solo-Annual-T","handle":"solo-annual-trial","description":"Users:
+        1\r\nPersonalities: 10","accounting_code":"11","request_credit_card":true,"expiration_interval":null,"expiration_interval_unit":"never","created_at":"2022-12-15T14:06:31.000Z","updated_at":"2022-12-15T14:06:31.000Z","price_in_cents":28800,"interval":12,"interval_unit":"month","initial_charge_in_cents":null,"trial_price_in_cents":0,"trial_interval":14,"trial_interval_unit":"day","archived_at":null,"require_credit_card":false,"return_params":"","taxable":false,"update_return_url":"","tax_code":"","initial_charge_after_trial":false,"version_number":1,"update_return_params":"","default_product_price_point_id":2245073,"request_billing_address":false,"require_billing_address":false,"require_shipping_address":false,"use_site_exchange_rate":true,"item_category":null,"product_price_point_id":2245073,"product_price_point_name":"New
+        Price May 2021","product_price_point_handle":"uuid:71f899e0-8c25-0139-8dc8-0a575a757c23","product_family":{"id":2473952,"name":"Blinkbid
+        - USA","description":"Blinkbid software sold in the United States, in USD
+        currency.","handle":"blinkbid-usa","accounting_code":null,"created_at":"2022-12-15T14:06:29.000Z","updated_at":"2022-12-15T14:06:29.000Z"},"public_signup_pages":[]},"credit_card":{"id":59640806,"first_name":"Joao","last_name":"Das
+        Neves","masked_card_number":"XXXX-XXXX-XXXX-3858","card_type":"visa","expiration_month":11,"expiration_year":2034,"customer_id":80219272,"current_vault":"bogus","vault_token":"1","billing_address":"123
+        Main St.","billing_city":"Boston","billing_state":"MA","billing_zip":"02120","billing_country":"US","customer_vault_token":null,"billing_address_2":"Addd2","payment_type":"credit_card","disabled":false,"site_gateway_setting_id":null,"gateway_handle":null}}}'
+    headers:
+      Authorization:
+      - "<CHARGIFY_API_KEY>"
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private, no-store
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 17 Jun 2024 17:50:53 GMT
+      Etag:
+      - W/"6edaef378beaed80e5cf15d7a3c273e0"
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - nginx + Phusion Passenger(R)
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - Phusion Passenger(R) Enterprise
+      X-Request-Id:
+      - da76bb44-4f7d-49cc-a69f-6a37c0676191
+      X-Runtime:
+      - '0.145024'
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Length:
+      - '529'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"payment_profile":{"id":59640935,"first_name":"Joao","last_name":"Das
+        Neves","masked_card_number":"XXXX-XXXX-XXXX-3858","card_type":"visa","expiration_month":11,"expiration_year":2034,"customer_id":80219272,"current_vault":"bogus","vault_token":"1","billing_address":"123
+        Main St.","billing_city":"Boston","billing_state":"MA","billing_zip":"02120","billing_country":"US","customer_vault_token":null,"billing_address_2":"Addd2","site_gateway_setting_id":null,"payment_type":"credit_card","disabled":false,"gateway_handle":null}}'
+  recorded_at: Mon, 17 Jun 2024 17:50:58 GMT
+recorded_with: VCR 6.2.0

--- a/spec/fixtures/cassettes/chargify_wrapper/subscription_change_default_payment_profile/when_subscription_is_not_found_raises_an_active_resource/resource_not_found_error.yml
+++ b/spec/fixtures/cassettes/chargify_wrapper/subscription_change_default_payment_profile/when_subscription_is_not_found_raises_an_active_resource/resource_not_found_error.yml
@@ -1,0 +1,128 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://<CHARGIFY_SUBDOMAIN>.chargify.com/payment_profiles.json
+    body:
+      encoding: UTF-8
+      string: '{"payment_profile":{"first_name":"Joao","last_name":"Das Neves","last_four":"3858","card_type":"visa","expiration_month":11,"expiration_year":2034,"customer_id":80219272,"current_vault":"bogus","vault_token":"1","billing_address":"123
+        Main St.","billing_city":"Boston","billing_state":"MA","billing_zip":"02120","billing_country":"US","billing_address_2":"Addd2","payment_type":"credit_card"}}'
+    headers:
+      Authorization:
+      - "<CHARGIFY_API_KEY>"
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Cache-Control:
+      - private, no-store
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 17 Jun 2024 17:50:57 GMT
+      Etag:
+      - W/"543c87ca1d1198241f8b34bdfbd7423b"
+      Location:
+      - "/payment_profiles/59640938"
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - nginx + Phusion Passenger(R)
+      Status:
+      - 201 Created
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - Phusion Passenger(R) Enterprise
+      X-Request-Id:
+      - c0ed7d7b-5a7f-4937-bd56-b5a1ee67ac16
+      X-Runtime:
+      - '0.074214'
+      X-Xss-Protection:
+      - 1; mode=block
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"payment_profile":{"id":59640938,"first_name":"Joao","last_name":"Das
+        Neves","masked_card_number":"XXXX-XXXX-XXXX-3858","card_type":"visa","expiration_month":11,"expiration_year":2034,"customer_id":80219272,"current_vault":"bogus","vault_token":"1","billing_address":"123
+        Main St.","billing_city":"Boston","billing_state":"MA","billing_zip":"02120","billing_country":"US","customer_vault_token":null,"billing_address_2":"Addd2","site_gateway_setting_id":null,"payment_type":"credit_card","disabled":false,"gateway_handle":null}}'
+  recorded_at: Mon, 17 Jun 2024 17:51:02 GMT
+- request:
+    method: post
+    uri: https://<CHARGIFY_SUBDOMAIN>.chargify.com/subscriptions/new/payment_profiles/59640938/change_payment_profile.json
+    body:
+      encoding: UTF-8
+      string: '{"subscription":{"id":12345678}}'
+    headers:
+      Authorization:
+      - "<CHARGIFY_API_KEY>"
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Cache-Control:
+      - private, no-store
+      Content-Type:
+      - text/html
+      Date:
+      - Mon, 17 Jun 2024 17:50:58 GMT
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - nginx + Phusion Passenger(R)
+      Status:
+      - 404 Not Found
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - Phusion Passenger(R) Enterprise
+      X-Request-Id:
+      - c14a0da5-12e9-4e91-97e2-df3b498c3578
+      X-Runtime:
+      - '0.020317'
+      X-Xss-Protection:
+      - 1; mode=block
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: ''
+  recorded_at: Mon, 17 Jun 2024 17:51:03 GMT
+recorded_with: VCR 6.2.0

--- a/spec/fixtures/cassettes/chargify_wrapper/subscription_delayed_cancel/when_subscription_is_active_returns_http_status_200.yml
+++ b/spec/fixtures/cassettes/chargify_wrapper/subscription_delayed_cancel/when_subscription_is_active_returns_http_status_200.yml
@@ -8,7 +8,7 @@ http_interactions:
       string: ''
     headers:
       Authorization:
-      - <CHARGIFY_API_KEY>
+      - "<CHARGIFY_API_KEY>"
       Accept:
       - application/json
       Accept-Encoding:
@@ -74,7 +74,7 @@ http_interactions:
       string: '{"cancellation_message":null,"reason_code":null}'
     headers:
       Authorization:
-      - <CHARGIFY_API_KEY>
+      - "<CHARGIFY_API_KEY>"
       Content-Type:
       - application/json
       Accept-Encoding:

--- a/spec/fixtures/cassettes/chargify_wrapper/subscription_delayed_cancel/when_subscription_is_invalid_return_http_status_404.yml
+++ b/spec/fixtures/cassettes/chargify_wrapper/subscription_delayed_cancel/when_subscription_is_invalid_return_http_status_404.yml
@@ -8,7 +8,7 @@ http_interactions:
       string: '{"cancellation_message":null,"reason_code":null}'
     headers:
       Authorization:
-      - <CHARGIFY_API_KEY>
+      - "<CHARGIFY_API_KEY>"
       Content-Type:
       - application/json
       Accept-Encoding:

--- a/spec/resources/subscription_spec.rb
+++ b/spec/resources/subscription_spec.rb
@@ -37,4 +37,100 @@ RSpec.describe ChargifyWrapper::Subscription do
       end
     end
   end
+
+  describe "#change_default_payment_profile", :vcr do
+    let(:subscription) { described_class.find(76354749) }
+
+    context "when payment profile is valid" do
+      let(:payment_profile) do
+        ChargifyWrapper::PaymentProfile.create({
+          payment_profile: {
+            first_name: "Joao",
+            last_name: "Das Neves",
+            last_four: "3858",
+            card_type: "visa",
+            expiration_month: 11,
+            expiration_year: 2034,
+            customer_id: 80219272,
+            current_vault: "bogus",
+            vault_token: "1",
+            billing_address: "123 Main St.",
+            billing_city: "Boston",
+            billing_state: "MA",
+            billing_zip: "02120",
+            billing_country: "US",
+            billing_address_2: "Addd2",
+            payment_type: "credit_card"
+          }
+        })
+      end
+
+      it "returns http status 200" do
+        expect(subscription.change_default_payment_profile(payment_profile)).to be_a(Net::HTTPOK)
+      end
+
+      it "changes the default payment profile" do
+        response = subscription.change_default_payment_profile(payment_profile)
+
+        parsed_response = JSON.parse(response.body)
+        expect(parsed_response["payment_profile"]["id"]).to eq(payment_profile.id)
+      end
+    end
+
+    context "when subscription is not found" do
+      let(:invalid_subscription) { described_class.new(id: 12345678) }
+
+      let(:payment_profile) do
+        ChargifyWrapper::PaymentProfile.create({
+          payment_profile: {
+            first_name: "Joao",
+            last_name: "Das Neves",
+            last_four: "3858",
+            card_type: "visa",
+            expiration_month: 11,
+            expiration_year: 2034,
+            customer_id: 80219272,
+            current_vault: "bogus",
+            vault_token: "1",
+            billing_address: "123 Main St.",
+            billing_city: "Boston",
+            billing_state: "MA",
+            billing_zip: "02120",
+            billing_country: "US",
+            billing_address_2: "Addd2",
+            payment_type: "credit_card"
+          }
+        })
+      end
+
+      it "raises an ActiveResource::ResourceNotFound error" do
+        expect {
+          invalid_subscription.change_default_payment_profile(payment_profile)
+        }.to raise_error(ActiveResource::ResourceNotFound)
+      end
+    end
+
+    context "when payment profile is not found" do
+      let(:non_existent_payment_profile) do
+        ChargifyWrapper::PaymentProfile.new({
+          id: 12345678,
+          subscription_id: subscription.id
+        })
+      end
+
+      it "raises an ActiveResource::ResourceNotFound error" do
+        expect {
+          subscription.change_default_payment_profile(non_existent_payment_profile)
+        }.to raise_error(ActiveResource::ResourceNotFound)
+      end
+    end
+
+    context "when changing the default payment profile fails" do
+      let(:invalid_payment_profile) do
+      end
+
+      it "raises a 422 Unprocessable Entity error" do
+      end
+    end
+  end
 end

--- a/spec/resources/subscription_spec.rb
+++ b/spec/resources/subscription_spec.rb
@@ -39,79 +39,55 @@ RSpec.describe ChargifyWrapper::Subscription do
   end
 
   describe "#change_default_payment_profile", :vcr do
-    let(:subscription) { described_class.find(76354749) }
+    subject(:change_payment_profile) { subscription.change_default_payment_profile(payment_profile) }
+
+    let(:payment_profile) do
+      ChargifyWrapper::PaymentProfile.create({
+        payment_profile: {
+          first_name: "Joao",
+          last_name: "Das Neves",
+          last_four: "3858",
+          card_type: "visa",
+          expiration_month: 11,
+          expiration_year: 2034,
+          customer_id: 80219272,
+          current_vault: "bogus",
+          vault_token: "1",
+          billing_address: "123 Main St.",
+          billing_city: "Boston",
+          billing_state: "MA",
+          billing_zip: "02120",
+          billing_country: "US",
+          billing_address_2: "Addd2",
+          payment_type: "credit_card"
+        }
+      })
+    end
 
     context "when payment profile is valid" do
-      let(:payment_profile) do
-        ChargifyWrapper::PaymentProfile.create({
-          payment_profile: {
-            first_name: "Joao",
-            last_name: "Das Neves",
-            last_four: "3858",
-            card_type: "visa",
-            expiration_month: 11,
-            expiration_year: 2034,
-            customer_id: 80219272,
-            current_vault: "bogus",
-            vault_token: "1",
-            billing_address: "123 Main St.",
-            billing_city: "Boston",
-            billing_state: "MA",
-            billing_zip: "02120",
-            billing_country: "US",
-            billing_address_2: "Addd2",
-            payment_type: "credit_card"
-          }
-        })
-      end
+      let(:subscription) { described_class.find(76354749) }
 
       it "returns http status 200" do
-        expect(subscription.change_default_payment_profile(payment_profile)).to be_a(Net::HTTPOK)
+        expect(change_payment_profile).to be_a(Net::HTTPOK)
       end
 
       it "changes the default payment profile" do
-        response = subscription.change_default_payment_profile(payment_profile)
-
-        parsed_response = JSON.parse(response.body)
+        parsed_response = JSON.parse(change_payment_profile.body)
         expect(parsed_response["payment_profile"]["id"]).to eq(payment_profile.id)
       end
     end
 
     context "when subscription is not found" do
-      let(:invalid_subscription) { described_class.new(id: 12345678) }
-
-      let(:payment_profile) do
-        ChargifyWrapper::PaymentProfile.create({
-          payment_profile: {
-            first_name: "Joao",
-            last_name: "Das Neves",
-            last_four: "3858",
-            card_type: "visa",
-            expiration_month: 11,
-            expiration_year: 2034,
-            customer_id: 80219272,
-            current_vault: "bogus",
-            vault_token: "1",
-            billing_address: "123 Main St.",
-            billing_city: "Boston",
-            billing_state: "MA",
-            billing_zip: "02120",
-            billing_country: "US",
-            billing_address_2: "Addd2",
-            payment_type: "credit_card"
-          }
-        })
-      end
+      let(:subscription) { described_class.new(id: 12345678) }
 
       it "raises an ActiveResource::ResourceNotFound error" do
-        expect {
-          invalid_subscription.change_default_payment_profile(payment_profile)
-        }.to raise_error(ActiveResource::ResourceNotFound)
+        expect { change_payment_profile }.to raise_error(ActiveResource::ResourceNotFound)
       end
     end
 
     context "when payment profile is not found" do
-      let(:non_existent_payment_profile) do
+      let(:subscription) { described_class.find(76354749) }
+      let(:payment_profile) do
         ChargifyWrapper::PaymentProfile.new({
           id: 12345678,
           subscription_id: subscription.id
@@ -119,17 +95,7 @@ RSpec.describe ChargifyWrapper::Subscription do
       end
 
       it "raises an ActiveResource::ResourceNotFound error" do
-        expect {
-          subscription.change_default_payment_profile(non_existent_payment_profile)
-        }.to raise_error(ActiveResource::ResourceNotFound)
-      end
-    end
-
-    context "when changing the default payment profile fails" do
-      let(:invalid_payment_profile) do
-      end
-
-      it "raises a 422 Unprocessable Entity error" do
+        expect { change_payment_profile }.to raise_error(ActiveResource::ResourceNotFound)
       end
     end
   end

--- a/spec/support/vcr_setup.rb
+++ b/spec/support/vcr_setup.rb
@@ -21,7 +21,7 @@ VCR.configure do |config|
   end
 
   config.filter_sensitive_data("<CHARGIFY_API_KEY>") do |interaction|
-    interaction.request.headers["Authorization"]
+    interaction.request.headers["Authorization"].first
   end
 end
 


### PR DESCRIPTION
[BB-1198](https://87labs.atlassian.net/browse/BB-1198)

### Feature
This pr adds Payment Profile to the ChargifyWrapper gem

### Setup
Install the gem on your local env
```bash
gem uninstall --force chargify_wrapper
gem build chargify_wrapper.gemspec --ouput=chargify_wrapper.gem
gem install chargify_wrapper --local chargify_wrapper.gem
```

### Q & A
Open an `irb` console
Require the gem and configure it
```ruby
require 'chargify_wrapper'
ChargifyWrapper.configure do |config|
  config.subdomain = SUBDOMAIN
  config.api_key = API_KEY
  config.log_requests = true
end
```
Create a new PaymentProfile associated with the customer of the selected subscription and  assign it to a `payment_profile` variable.
Call the method that sends the request to chargify 
```ruby
ChargifyWrapper::Subscription.find(<SUBSCRIPTION_ID>).change_default_payment_profile(payment_profile)
```
- In Chargify -> subscription -> payment details, the card **should be created and set as default**
