### PR TITLE
feat(coupon): add validate coupon method

### DIFF
--- a/lib/chargify_wrapper.rb
+++ b/lib/chargify_wrapper.rb
@@ -2,6 +2,7 @@
 
 require "active_resource"
 require "chargify_wrapper/resources/base"
+require "chargify_wrapper/resources/coupon"
 require "chargify_wrapper/resources/subscription"
 require "chargify_wrapper/resources/payment_profile"
 require "chargify_wrapper/config"

--- a/lib/chargify_wrapper/resources/coupon.rb
+++ b/lib/chargify_wrapper/resources/coupon.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module ChargifyWrapper
+  class Coupon < Base
+    class << self
+      def validate(code, product_family_id: nil)
+        params = { code: code }
+
+        params.merge!(product_family_id: product_family_id) if product_family_id
+
+        get(:validate, params)
+      end
+    end
+  end
+end

--- a/lib/chargify_wrapper/resources/coupon.rb
+++ b/lib/chargify_wrapper/resources/coupon.rb
@@ -4,9 +4,9 @@ module ChargifyWrapper
   class Coupon < Base
     class << self
       def validate(code, product_family_id: nil)
-        params = { code: code }
+        params = {code: code}
 
-        params.merge!(product_family_id: product_family_id) if product_family_id
+        params[:product_family_id] = product_family_id if product_family_id
 
         get(:validate, params)
       end

--- a/spec/fixtures/cassettes/chargify_wrapper/coupon_validate/when_coupon_is_existent_and_valid_.yml
+++ b/spec/fixtures/cassettes/chargify_wrapper/coupon_validate/when_coupon_is_existent_and_valid_.yml
@@ -1,0 +1,65 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://<CHARGIFY_SUBDOMAIN>.chargify.com/coupons/validate.json?code=GENERALCOUPON
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - "<CHARGIFY_API_KEY>"
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private, no-store
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 11 Jul 2024 21:10:15 GMT
+      Etag:
+      - W/"64567b53db6d10414a6cbf7cc2ae2a7d"
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - nginx + Phusion Passenger(R)
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - Phusion Passenger(R) Enterprise
+      X-Request-Id:
+      - 49fc7092-6241-4725-92db-c8c14dbeabec
+      X-Runtime:
+      - '0.062159'
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Length:
+      - '961'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"coupon":{"id":655202,"name":"general coupon","code":"GENERALCOUPON","description":"coupon
+        without restrictions","amount":10.0,"amount_in_cents":1000,"product_family_id":1726157,"product_family_name":"Blinkbid
+        - USA","start_date":"2024-07-10T09:10:36-07:00","end_date":"2024-07-11T23:59:59-07:00","percentage":null,"recurring":false,"recurring_scheme":"do_not_recur","duration_period_count":null,"duration_interval":null,"duration_interval_unit":null,"duration_interval_span":"1_month","allow_negative_balance":false,"archived_at":null,"conversion_limit":null,"stackable":false,"compounding_strategy":null,"created_at":"2024-07-10T09:10:36-07:00","updated_at":"2024-07-11T08:46:05-07:00","discount_type":"amount","exclude_mid_period_allocations":false,"apply_on_cancel_at_end_of_period":false,"apply_on_subscription_expiration":false,"coupon_restrictions":[{"id":1389060,"item_type":"Product","item_id":5505198,"name":"Lite-Monthly","handle":"lite-monthly"}]}}'
+  recorded_at: Thu, 11 Jul 2024 21:10:15 GMT
+recorded_with: VCR 6.2.0

--- a/spec/fixtures/cassettes/chargify_wrapper/coupon_validate/when_coupon_is_existent_but_not_valid_.yml
+++ b/spec/fixtures/cassettes/chargify_wrapper/coupon_validate/when_coupon_is_existent_but_not_valid_.yml
@@ -1,0 +1,59 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://<CHARGIFY_SUBDOMAIN>.chargify.com/coupons/validate.json?code=25RDJMSNET
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - "<CHARGIFY_API_KEY>"
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Cache-Control:
+      - private, no-store
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 11 Jul 2024 21:10:17 GMT
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - nginx + Phusion Passenger(R)
+      Status:
+      - 404 Not Found
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - Phusion Passenger(R) Enterprise
+      X-Request-Id:
+      - 34fd9d86-868a-400b-bf34-7cbd6305d2e7
+      X-Runtime:
+      - '0.020065'
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Length:
+      - '43'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"errors":"That coupon offer has expired."}'
+  recorded_at: Thu, 11 Jul 2024 21:10:17 GMT
+recorded_with: VCR 6.2.0

--- a/spec/fixtures/cassettes/chargify_wrapper/coupon_validate/when_coupon_is_not_existent_.yml
+++ b/spec/fixtures/cassettes/chargify_wrapper/coupon_validate/when_coupon_is_not_existent_.yml
@@ -1,0 +1,59 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://<CHARGIFY_SUBDOMAIN>.chargify.com/coupons/validate.json?code=ANYCOUPON
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - "<CHARGIFY_API_KEY>"
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Cache-Control:
+      - private, no-store
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 11 Jul 2024 21:10:16 GMT
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - nginx + Phusion Passenger(R)
+      Status:
+      - 404 Not Found
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - Phusion Passenger(R) Enterprise
+      X-Request-Id:
+      - aac16399-deac-43b2-a1bf-105287b550ef
+      X-Runtime:
+      - '0.022490'
+      X-Xss-Protection:
+      - 1; mode=block
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"errors":"Coupon code could not be found."}'
+  recorded_at: Thu, 11 Jul 2024 21:10:16 GMT
+recorded_with: VCR 6.2.0

--- a/spec/resources/coupon_spec.rb
+++ b/spec/resources/coupon_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe ChargifyWrapper::Coupon do
+  describe "#validate", :vcr do
+    subject { described_class.validate(coupon) }
+
+    context "when coupon is existent and valid" do
+      let(:coupon) { "GENERALCOUPON" }
+
+      it { expect(subject).to be_present }
+    end
+
+    context "when coupon is not existent" do
+      let(:coupon) { "ANYCOUPON" }
+
+      it { expect { subject }.to raise_error(ActiveResource::ResourceNotFound) }
+    end
+
+    context "when coupon is existent but not valid" do
+      let(:coupon) { "25RDJMSNET" }
+
+      it { expect { subject }.to raise_error(ActiveResource::ResourceNotFound) }
+    end
+  end
+end

--- a/spec/resources/coupon_spec.rb
+++ b/spec/resources/coupon_spec.rb
@@ -4,24 +4,24 @@ require "spec_helper"
 
 RSpec.describe ChargifyWrapper::Coupon do
   describe "#validate", :vcr do
-    subject { described_class.validate(coupon) }
+    subject(:validate_coupon) { described_class.validate(coupon) }
 
     context "when coupon is existent and valid" do
       let(:coupon) { "GENERALCOUPON" }
 
-      it { expect(subject).to be_present }
+      it { expect(validate_coupon).to be_present }
     end
 
     context "when coupon is not existent" do
       let(:coupon) { "ANYCOUPON" }
 
-      it { expect { subject }.to raise_error(ActiveResource::ResourceNotFound) }
+      it { expect { validate_coupon }.to raise_error(ActiveResource::ResourceNotFound) }
     end
 
     context "when coupon is existent but not valid" do
       let(:coupon) { "25RDJMSNET" }
 
-      it { expect { subject }.to raise_error(ActiveResource::ResourceNotFound) }
+      it { expect { validate_coupon }.to raise_error(ActiveResource::ResourceNotFound) }
     end
   end
 end


### PR DESCRIPTION
[BB-1242](https://87labs.atlassian.net/browse/BB-1242)

### Feature

Add new `ChargifyWrapper::Coupon` class with `.validate` class method, which expects a coupon code and a optional `product_family_id`
If the provided code exists and it is valid, the coupon gets returned. If not, a `ActiveResource::ResourceNotFound` is raised, which is a 404

The `product_family_id` is optional and has the purpose of removing ambiguity when looking for the coupon, given that you can have the same code on multiple product families

### Setup

Build and install the gem as described on README

### Q & A

Run the following in a `irb` console, providing different coupon codes:

```ruby
require 'chargify_wrapper'

ChargifyWrapper.configure do |config|
  config.subdomain = 'your-subdomain'
  config.api_key = 'your-api-key'
end

ChargifyWrapper::Coupon(CODE)
```

If the code is valid, a `ChargifyWrapper::Coupon` instance should be returned
If the code does not exist or is invalid (like expired, for example), it should raise `ActiveResource::ResourceNotFound`
 