### PR TITLE
fix(base): remove error handling method from gem

### DIFF
--- a/lib/chargify_wrapper/resources/base.rb
+++ b/lib/chargify_wrapper/resources/base.rb
@@ -3,18 +3,5 @@
 module ChargifyWrapper
   class Base < ActiveResource::Base
     self.include_root_in_json = true
-
-    private
-
-    def handle_errors(&block)
-      yield if block
-    rescue ActiveResource::ResourceInvalid => e
-      body = JSON.parse(e.response.body)
-      errors = body.fetch(self.class.element_name) { body["errors"] }
-
-      self.errors.from_array(errors)
-
-      self
-    end
   end
 end

--- a/lib/chargify_wrapper/resources/subscription.rb
+++ b/lib/chargify_wrapper/resources/subscription.rb
@@ -17,12 +17,10 @@ module ChargifyWrapper
     end
 
     def reactivate(attrs = {})
-      handle_errors do
-        put(
-          :reactivate, nil,
-          attrs.to_json(root: :subscription)
-        )
-      end
+      put(
+        :reactivate, nil,
+        attrs.to_json(root: :subscription)
+      )
     end
   end
 end

--- a/spec/fixtures/cassettes/chargify_wrapper/subscription_reactivate/when_reactivation_fails_.yml
+++ b/spec/fixtures/cassettes/chargify_wrapper/subscription_reactivate/when_reactivation_fails_.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://<CHARGIFY_SUBDOMAIN>.chargify.com/subscriptions/77228576.json
+    uri: https://<CHARGIFY_SUBDOMAIN>.chargify.com/subscriptions/76900225.json
     body:
       encoding: US-ASCII
       string: ''
@@ -25,9 +25,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 12 Jul 2024 17:42:10 GMT
+      - Fri, 19 Jul 2024 15:49:06 GMT
       Etag:
-      - W/"7aa96cb7ad6ef6331992d948a305424f"
+      - W/"177ca77bd2a0b5f3c1a77cd5a825b8ad"
       Referrer-Policy:
       - strict-origin-when-cross-origin
       Server:
@@ -47,9 +47,9 @@ http_interactions:
       X-Powered-By:
       - Phusion Passenger(R) Enterprise
       X-Request-Id:
-      - b931def8-ce31-48f3-b73a-24db6acfe8fd
+      - 822be3a1-521c-4d44-a0d2-375260c15e44
       X-Runtime:
-      - '0.173206'
+      - '0.140960'
       X-Xss-Protection:
       - 1; mode=block
       Transfer-Encoding:
@@ -58,11 +58,69 @@ http_interactions:
       - keep-alive
     body:
       encoding: UTF-8
-      string: '{"subscription":{"id":77228576,"state":"active","trial_started_at":"2024-07-12T07:03:44-07:00","trial_ended_at":"2024-07-12T07:09:00-07:00","activated_at":"2024-07-12T07:26:17-07:00","created_at":"2024-07-12T07:03:44-07:00","updated_at":"2024-07-12T07:31:14-07:00","expires_at":null,"balance_in_cents":0,"current_period_ends_at":"2025-07-12T07:26:17-07:00","next_assessment_at":"2025-07-12T07:26:17-07:00","canceled_at":null,"cancellation_message":null,"next_product_id":null,"next_product_handle":null,"cancel_at_end_of_period":false,"payment_collection_method":"automatic","snap_day":null,"cancellation_method":null,"current_period_started_at":"2024-07-12T07:26:17-07:00","previous_state":"trial_ended","signup_payment_id":1110911031,"signup_revenue":"0.00","delayed_cancel_at":null,"coupon_code":null,"total_revenue_in_cents":28800,"product_price_in_cents":28800,"product_version_number":1,"payment_type":"credit_card","referral_code":null,"coupon_use_count":null,"coupon_uses_allowed":null,"reason_code":null,"automatically_resume_at":null,"coupon_codes":[],"offer_id":null,"payer_id":null,"receives_invoice_emails":null,"product_price_point_id":2245073,"next_product_price_point_id":null,"net_terms":null,"stored_credential_transaction_id":null,"reference":null,"currency":"USD","on_hold_at":null,"scheduled_cancellation_at":null,"product_price_point_type":"default","dunning_communication_delay_enabled":false,"dunning_communication_delay_time_zone":null,"current_billing_amount_in_cents":28800,"customer":{"id":81124896,"first_name":"Luana","last_name":"3","organization":null,"email":"ls3@gmail.com","created_at":"2024-07-12T07:03:44-07:00","updated_at":"2024-07-12T07:03:44-07:00","reference":null,"address":null,"address_2":null,"city":null,"state":null,"state_name":null,"zip":null,"country":null,"country_name":null,"phone":null,"portal_invite_last_sent_at":null,"portal_invite_last_accepted_at":null,"verified":false,"portal_customer_created_at":null,"vat_number":null,"cc_emails":null,"tax_exempt":false,"parent_id":null},"product":{"id":6388932,"name":"Solo","handle":"solo-annual-trial","description":"Users:
-        1\r\nPersonalities: 10","accounting_code":"11","request_credit_card":true,"expiration_interval":null,"expiration_interval_unit":"never","created_at":"2022-12-15T06:06:31-08:00","updated_at":"2024-07-01T10:16:15-07:00","price_in_cents":28800,"interval":12,"interval_unit":"month","initial_charge_in_cents":null,"trial_price_in_cents":0,"trial_interval":14,"trial_interval_unit":"day","archived_at":null,"require_credit_card":false,"return_params":"","taxable":false,"update_return_url":"","tax_code":"","initial_charge_after_trial":false,"version_number":1,"update_return_params":"","default_product_price_point_id":2245073,"request_billing_address":false,"require_billing_address":false,"require_shipping_address":false,"use_site_exchange_rate":true,"item_category":null,"product_price_point_id":2245073,"product_price_point_name":"New
-        Price May 2021","product_price_point_handle":"uuid:71f899e0-8c25-0139-8dc8-0a575a757c23","product_family":{"id":2473952,"name":"Blinkbid
+      string: '{"subscription":{"id":76900225,"state":"active","trial_started_at":"2024-06-28T07:23:22-07:00","trial_ended_at":"2024-06-28T07:41:00-07:00","activated_at":"2024-07-10T10:40:26-07:00","created_at":"2024-06-28T07:23:22-07:00","updated_at":"2024-07-10T10:40:26-07:00","expires_at":null,"balance_in_cents":0,"current_period_ends_at":"2024-08-10T10:40:26-07:00","next_assessment_at":"2024-08-10T10:40:26-07:00","canceled_at":null,"cancellation_message":null,"next_product_id":null,"next_product_handle":null,"cancel_at_end_of_period":false,"payment_collection_method":"automatic","snap_day":null,"cancellation_method":null,"current_period_started_at":"2024-07-10T10:40:26-07:00","previous_state":"trial_ended","signup_payment_id":1100331778,"signup_revenue":"0.00","delayed_cancel_at":null,"coupon_code":null,"total_revenue_in_cents":2800,"product_price_in_cents":2800,"product_version_number":1,"payment_type":"credit_card","referral_code":null,"coupon_use_count":null,"coupon_uses_allowed":null,"reason_code":null,"automatically_resume_at":null,"coupon_codes":[],"offer_id":null,"payer_id":null,"receives_invoice_emails":null,"product_price_point_id":2245037,"next_product_price_point_id":null,"net_terms":null,"stored_credential_transaction_id":null,"reference":null,"currency":"USD","on_hold_at":null,"scheduled_cancellation_at":null,"product_price_point_type":"default","dunning_communication_delay_enabled":false,"dunning_communication_delay_time_zone":null,"current_billing_amount_in_cents":2800,"customer":{"id":80814832,"first_name":"Luana","last_name":"1","organization":null,"email":"ls1@gmail.com","created_at":"2024-06-28T07:23:22-07:00","updated_at":"2024-06-28T07:23:22-07:00","reference":null,"address":null,"address_2":null,"city":null,"state":null,"state_name":null,"zip":null,"country":null,"country_name":null,"phone":null,"portal_invite_last_sent_at":null,"portal_invite_last_accepted_at":null,"verified":false,"portal_customer_created_at":null,"vat_number":null,"cc_emails":null,"tax_exempt":false,"parent_id":null},"product":{"id":6388924,"name":"Solo","handle":"solo-monthly-trial","description":"Users:
+        1\r\nPersonalities: 10","accounting_code":"13","request_credit_card":true,"expiration_interval":null,"expiration_interval_unit":"never","created_at":"2022-12-15T06:06:29-08:00","updated_at":"2024-07-01T10:15:20-07:00","price_in_cents":2800,"interval":1,"interval_unit":"month","initial_charge_in_cents":null,"trial_price_in_cents":0,"trial_interval":14,"trial_interval_unit":"day","archived_at":null,"require_credit_card":false,"return_params":"","taxable":false,"update_return_url":"","tax_code":"","initial_charge_after_trial":false,"version_number":1,"update_return_params":"","default_product_price_point_id":2245037,"request_billing_address":false,"require_billing_address":false,"require_shipping_address":false,"use_site_exchange_rate":true,"item_category":null,"product_price_point_id":2245037,"product_price_point_name":"New
+        Price May 2021","product_price_point_handle":"uuid:2feeb150-8c25-0139-e08c-06de0fa030d9","product_family":{"id":2473952,"name":"Blinkbid
         - USA","description":"Blinkbid software sold in the United States, in USD
-        currency.","handle":"blinkbid-usa","accounting_code":null,"created_at":"2022-12-15T06:06:29-08:00","updated_at":"2022-12-15T06:06:29-08:00"},"public_signup_pages":[]},"credit_card":{"id":60064649,"first_name":"Johnn","last_name":"Doeee","masked_card_number":"XXXX-XXXX-XXXX-1111","card_type":"visa","expiration_month":4,"expiration_year":2033,"customer_id":81124896,"current_vault":"bogus","vault_token":"1","billing_address":"Los
-        Angeles","billing_city":"LA","billing_state":"AL","billing_zip":"1212121212","billing_country":"US","customer_vault_token":null,"billing_address_2":null,"payment_type":"credit_card","disabled":false,"site_gateway_setting_id":null,"gateway_handle":null}}}'
-  recorded_at: Fri, 12 Jul 2024 17:42:16 GMT
+        currency.","handle":"blinkbid-usa","accounting_code":null,"created_at":"2022-12-15T06:06:29-08:00","updated_at":"2022-12-15T06:06:29-08:00"},"public_signup_pages":[]},"credit_card":{"id":59954200,"first_name":"Johnn","last_name":"Doeeewewe","masked_card_number":"XXXX-XXXX-XXXX-1","card_type":"bogus","expiration_month":12,"expiration_year":2032,"customer_id":80814832,"current_vault":"bogus","vault_token":"1","billing_address":null,"billing_city":null,"billing_state":null,"billing_zip":null,"billing_country":null,"customer_vault_token":null,"billing_address_2":null,"payment_type":"credit_card","disabled":false,"site_gateway_setting_id":26995,"gateway_handle":null}}}'
+  recorded_at: Fri, 19 Jul 2024 15:49:12 GMT
+- request:
+    method: put
+    uri: https://<CHARGIFY_SUBDOMAIN>.chargify.com/subscriptions/76900225/reactivate.json
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Authorization:
+      - "<CHARGIFY_API_KEY>"
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 422
+      message: Unprocessable Entity
+    headers:
+      Cache-Control:
+      - private, no-store
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 19 Jul 2024 15:49:07 GMT
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - nginx + Phusion Passenger(R)
+      Status:
+      - 422 Unprocessable Entity
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - Phusion Passenger(R) Enterprise
+      X-Request-Id:
+      - 0d901884-95d2-4467-83f1-55e68a119797
+      X-Runtime:
+      - '0.110873'
+      X-Xss-Protection:
+      - 1; mode=block
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"errors":["Cannot reactivate a subscription that is not marked \"Canceled\"
+        or \"Trial Ended\"."]}'
+  recorded_at: Fri, 19 Jul 2024 15:49:13 GMT
 recorded_with: VCR 6.2.0

--- a/spec/fixtures/cassettes/chargify_wrapper/subscription_reactivate/when_subscription_is_on_trial_ended_state_reactivates_the_subscription.yml
+++ b/spec/fixtures/cassettes/chargify_wrapper/subscription_reactivate/when_subscription_is_on_trial_ended_state_reactivates_the_subscription.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://<CHARGIFY_SUBDOMAIN>.chargify.com/subscriptions/77228697.json
+    uri: https://<CHARGIFY_SUBDOMAIN>.chargify.com/subscriptions/77390750.json
     body:
       encoding: US-ASCII
       string: ''
@@ -25,9 +25,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 12 Jul 2024 17:42:06 GMT
+      - Fri, 19 Jul 2024 15:49:02 GMT
       Etag:
-      - W/"3752cf6a4dae95193f4e1586e375ed17"
+      - W/"e09b01813bb971ae302748433da8a3e5"
       Referrer-Policy:
       - strict-origin-when-cross-origin
       Server:
@@ -47,27 +47,27 @@ http_interactions:
       X-Powered-By:
       - Phusion Passenger(R) Enterprise
       X-Request-Id:
-      - 9ae590df-ef54-49f8-b3d8-07b66da9cb64
+      - da2f6c95-80aa-46d6-9f62-3d1aea2c9087
       X-Runtime:
-      - '0.126612'
+      - '0.111866'
       X-Xss-Protection:
       - 1; mode=block
       Content-Length:
-      - '3857'
+      - '3856'
       Connection:
       - keep-alive
     body:
       encoding: UTF-8
-      string: '{"subscription":{"id":77228697,"state":"active","trial_started_at":"2024-07-12T07:06:12-07:00","trial_ended_at":"2024-07-12T07:10:00-07:00","activated_at":"2024-07-12T09:14:12-07:00","created_at":"2024-07-12T07:06:12-07:00","updated_at":"2024-07-12T10:42:05-07:00","expires_at":null,"balance_in_cents":0,"current_period_ends_at":"2025-07-12T09:14:12-07:00","next_assessment_at":"2025-07-12T09:14:12-07:00","canceled_at":null,"cancellation_message":null,"next_product_id":null,"next_product_handle":null,"cancel_at_end_of_period":false,"payment_collection_method":"automatic","snap_day":null,"cancellation_method":null,"current_period_started_at":"2024-07-12T09:14:12-07:00","previous_state":"trial_ended","signup_payment_id":1110911377,"signup_revenue":"0.00","delayed_cancel_at":null,"coupon_code":null,"total_revenue_in_cents":28800,"product_price_in_cents":28800,"product_version_number":1,"payment_type":"credit_card","referral_code":null,"coupon_use_count":null,"coupon_uses_allowed":null,"reason_code":null,"automatically_resume_at":null,"coupon_codes":[],"offer_id":null,"payer_id":null,"receives_invoice_emails":null,"product_price_point_id":2245073,"next_product_price_point_id":null,"net_terms":null,"stored_credential_transaction_id":null,"reference":null,"currency":"USD","on_hold_at":null,"scheduled_cancellation_at":null,"product_price_point_type":"default","dunning_communication_delay_enabled":false,"dunning_communication_delay_time_zone":null,"current_billing_amount_in_cents":28800,"customer":{"id":81125010,"first_name":"Luana","last_name":"8","organization":null,"email":"ls8@gmail.com","created_at":"2024-07-12T07:06:12-07:00","updated_at":"2024-07-12T07:06:12-07:00","reference":null,"address":null,"address_2":null,"city":null,"state":null,"state_name":null,"zip":null,"country":null,"country_name":null,"phone":null,"portal_invite_last_sent_at":null,"portal_invite_last_accepted_at":null,"verified":false,"portal_customer_created_at":null,"vat_number":null,"cc_emails":null,"tax_exempt":false,"parent_id":null},"product":{"id":6388932,"name":"Solo","handle":"solo-annual-trial","description":"Users:
+      string: '{"subscription":{"id":77390750,"state":"active","trial_started_at":"2024-07-19T06:08:04-07:00","trial_ended_at":"2024-07-19T06:15:00-07:00","activated_at":"2024-07-19T08:49:00-07:00","created_at":"2024-07-19T06:08:04-07:00","updated_at":"2024-07-19T08:49:00-07:00","expires_at":null,"balance_in_cents":0,"current_period_ends_at":"2025-07-19T08:49:00-07:00","next_assessment_at":"2025-07-19T08:49:00-07:00","canceled_at":null,"cancellation_message":null,"next_product_id":null,"next_product_handle":null,"cancel_at_end_of_period":false,"payment_collection_method":"automatic","snap_day":null,"cancellation_method":null,"current_period_started_at":"2024-07-19T08:49:00-07:00","previous_state":"trial_ended","signup_payment_id":1114690124,"signup_revenue":"0.00","delayed_cancel_at":null,"coupon_code":null,"total_revenue_in_cents":28800,"product_price_in_cents":28800,"product_version_number":1,"payment_type":"credit_card","referral_code":null,"coupon_use_count":null,"coupon_uses_allowed":null,"reason_code":null,"automatically_resume_at":null,"coupon_codes":[],"offer_id":null,"payer_id":null,"receives_invoice_emails":null,"product_price_point_id":2245073,"next_product_price_point_id":null,"net_terms":null,"stored_credential_transaction_id":null,"reference":null,"currency":"USD","on_hold_at":null,"scheduled_cancellation_at":null,"product_price_point_type":"default","dunning_communication_delay_enabled":false,"dunning_communication_delay_time_zone":null,"current_billing_amount_in_cents":28800,"customer":{"id":81446471,"first_name":"Luana","last_name":"3","organization":null,"email":"a3@gmail.com","created_at":"2024-07-19T06:08:04-07:00","updated_at":"2024-07-19T06:08:04-07:00","reference":null,"address":null,"address_2":null,"city":null,"state":null,"state_name":null,"zip":null,"country":null,"country_name":null,"phone":null,"portal_invite_last_sent_at":null,"portal_invite_last_accepted_at":null,"verified":false,"portal_customer_created_at":null,"vat_number":null,"cc_emails":null,"tax_exempt":false,"parent_id":null},"product":{"id":6388932,"name":"Solo","handle":"solo-annual-trial","description":"Users:
         1\r\nPersonalities: 10","accounting_code":"11","request_credit_card":true,"expiration_interval":null,"expiration_interval_unit":"never","created_at":"2022-12-15T06:06:31-08:00","updated_at":"2024-07-01T10:16:15-07:00","price_in_cents":28800,"interval":12,"interval_unit":"month","initial_charge_in_cents":null,"trial_price_in_cents":0,"trial_interval":14,"trial_interval_unit":"day","archived_at":null,"require_credit_card":false,"return_params":"","taxable":false,"update_return_url":"","tax_code":"","initial_charge_after_trial":false,"version_number":1,"update_return_params":"","default_product_price_point_id":2245073,"request_billing_address":false,"require_billing_address":false,"require_shipping_address":false,"use_site_exchange_rate":true,"item_category":null,"product_price_point_id":2245073,"product_price_point_name":"New
         Price May 2021","product_price_point_handle":"uuid:71f899e0-8c25-0139-8dc8-0a575a757c23","product_family":{"id":2473952,"name":"Blinkbid
         - USA","description":"Blinkbid software sold in the United States, in USD
-        currency.","handle":"blinkbid-usa","accounting_code":null,"created_at":"2022-12-15T06:06:29-08:00","updated_at":"2022-12-15T06:06:29-08:00"},"public_signup_pages":[]},"credit_card":{"id":60069023,"first_name":"Johnn","last_name":"Doeee","masked_card_number":"XXXX-XXXX-XXXX-1111","card_type":"visa","expiration_month":7,"expiration_year":2033,"customer_id":81125010,"current_vault":"bogus","vault_token":"1","billing_address":"Los
-        Angeles","billing_city":"LA","billing_state":"AK","billing_zip":"1212121212","billing_country":"US","customer_vault_token":null,"billing_address_2":null,"payment_type":"credit_card","disabled":false,"site_gateway_setting_id":null,"gateway_handle":null}}}'
-  recorded_at: Fri, 12 Jul 2024 17:42:12 GMT
+        currency.","handle":"blinkbid-usa","accounting_code":null,"created_at":"2022-12-15T06:06:29-08:00","updated_at":"2022-12-15T06:06:29-08:00"},"public_signup_pages":[]},"credit_card":{"id":60180134,"first_name":"Johnn","last_name":"Doeee","masked_card_number":"XXXX-XXXX-XXXX-1111","card_type":"visa","expiration_month":4,"expiration_year":2030,"customer_id":81446471,"current_vault":"bogus","vault_token":"1","billing_address":"Los
+        Angeles","billing_city":"LA","billing_state":"AL","billing_zip":"1212121212","billing_country":"US","customer_vault_token":null,"billing_address_2":null,"payment_type":"credit_card","disabled":false,"site_gateway_setting_id":null,"gateway_handle":null}}}'
+  recorded_at: Fri, 19 Jul 2024 15:49:07 GMT
 - request:
     method: get
-    uri: https://<CHARGIFY_SUBDOMAIN>.chargify.com/subscriptions/77228697.json
+    uri: https://<CHARGIFY_SUBDOMAIN>.chargify.com/subscriptions/77390750.json
     body:
       encoding: US-ASCII
       string: ''
@@ -90,9 +90,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 12 Jul 2024 17:42:07 GMT
+      - Fri, 19 Jul 2024 15:49:03 GMT
       Etag:
-      - W/"3752cf6a4dae95193f4e1586e375ed17"
+      - W/"e09b01813bb971ae302748433da8a3e5"
       Referrer-Policy:
       - strict-origin-when-cross-origin
       Server:
@@ -112,9 +112,9 @@ http_interactions:
       X-Powered-By:
       - Phusion Passenger(R) Enterprise
       X-Request-Id:
-      - c72656da-3287-43cb-81b7-b6df2b5a5745
+      - 3176c937-7137-4a5f-8068-e70fc7914b7a
       X-Runtime:
-      - '0.122628'
+      - '0.257179'
       X-Xss-Protection:
       - 1; mode=block
       Transfer-Encoding:
@@ -123,11 +123,11 @@ http_interactions:
       - keep-alive
     body:
       encoding: UTF-8
-      string: '{"subscription":{"id":77228697,"state":"active","trial_started_at":"2024-07-12T07:06:12-07:00","trial_ended_at":"2024-07-12T07:10:00-07:00","activated_at":"2024-07-12T09:14:12-07:00","created_at":"2024-07-12T07:06:12-07:00","updated_at":"2024-07-12T10:42:05-07:00","expires_at":null,"balance_in_cents":0,"current_period_ends_at":"2025-07-12T09:14:12-07:00","next_assessment_at":"2025-07-12T09:14:12-07:00","canceled_at":null,"cancellation_message":null,"next_product_id":null,"next_product_handle":null,"cancel_at_end_of_period":false,"payment_collection_method":"automatic","snap_day":null,"cancellation_method":null,"current_period_started_at":"2024-07-12T09:14:12-07:00","previous_state":"trial_ended","signup_payment_id":1110911377,"signup_revenue":"0.00","delayed_cancel_at":null,"coupon_code":null,"total_revenue_in_cents":28800,"product_price_in_cents":28800,"product_version_number":1,"payment_type":"credit_card","referral_code":null,"coupon_use_count":null,"coupon_uses_allowed":null,"reason_code":null,"automatically_resume_at":null,"coupon_codes":[],"offer_id":null,"payer_id":null,"receives_invoice_emails":null,"product_price_point_id":2245073,"next_product_price_point_id":null,"net_terms":null,"stored_credential_transaction_id":null,"reference":null,"currency":"USD","on_hold_at":null,"scheduled_cancellation_at":null,"product_price_point_type":"default","dunning_communication_delay_enabled":false,"dunning_communication_delay_time_zone":null,"current_billing_amount_in_cents":28800,"customer":{"id":81125010,"first_name":"Luana","last_name":"8","organization":null,"email":"ls8@gmail.com","created_at":"2024-07-12T07:06:12-07:00","updated_at":"2024-07-12T07:06:12-07:00","reference":null,"address":null,"address_2":null,"city":null,"state":null,"state_name":null,"zip":null,"country":null,"country_name":null,"phone":null,"portal_invite_last_sent_at":null,"portal_invite_last_accepted_at":null,"verified":false,"portal_customer_created_at":null,"vat_number":null,"cc_emails":null,"tax_exempt":false,"parent_id":null},"product":{"id":6388932,"name":"Solo","handle":"solo-annual-trial","description":"Users:
+      string: '{"subscription":{"id":77390750,"state":"active","trial_started_at":"2024-07-19T06:08:04-07:00","trial_ended_at":"2024-07-19T06:15:00-07:00","activated_at":"2024-07-19T08:49:00-07:00","created_at":"2024-07-19T06:08:04-07:00","updated_at":"2024-07-19T08:49:00-07:00","expires_at":null,"balance_in_cents":0,"current_period_ends_at":"2025-07-19T08:49:00-07:00","next_assessment_at":"2025-07-19T08:49:00-07:00","canceled_at":null,"cancellation_message":null,"next_product_id":null,"next_product_handle":null,"cancel_at_end_of_period":false,"payment_collection_method":"automatic","snap_day":null,"cancellation_method":null,"current_period_started_at":"2024-07-19T08:49:00-07:00","previous_state":"trial_ended","signup_payment_id":1114690124,"signup_revenue":"0.00","delayed_cancel_at":null,"coupon_code":null,"total_revenue_in_cents":28800,"product_price_in_cents":28800,"product_version_number":1,"payment_type":"credit_card","referral_code":null,"coupon_use_count":null,"coupon_uses_allowed":null,"reason_code":null,"automatically_resume_at":null,"coupon_codes":[],"offer_id":null,"payer_id":null,"receives_invoice_emails":null,"product_price_point_id":2245073,"next_product_price_point_id":null,"net_terms":null,"stored_credential_transaction_id":null,"reference":null,"currency":"USD","on_hold_at":null,"scheduled_cancellation_at":null,"product_price_point_type":"default","dunning_communication_delay_enabled":false,"dunning_communication_delay_time_zone":null,"current_billing_amount_in_cents":28800,"customer":{"id":81446471,"first_name":"Luana","last_name":"3","organization":null,"email":"a3@gmail.com","created_at":"2024-07-19T06:08:04-07:00","updated_at":"2024-07-19T06:08:04-07:00","reference":null,"address":null,"address_2":null,"city":null,"state":null,"state_name":null,"zip":null,"country":null,"country_name":null,"phone":null,"portal_invite_last_sent_at":null,"portal_invite_last_accepted_at":null,"verified":false,"portal_customer_created_at":null,"vat_number":null,"cc_emails":null,"tax_exempt":false,"parent_id":null},"product":{"id":6388932,"name":"Solo","handle":"solo-annual-trial","description":"Users:
         1\r\nPersonalities: 10","accounting_code":"11","request_credit_card":true,"expiration_interval":null,"expiration_interval_unit":"never","created_at":"2022-12-15T06:06:31-08:00","updated_at":"2024-07-01T10:16:15-07:00","price_in_cents":28800,"interval":12,"interval_unit":"month","initial_charge_in_cents":null,"trial_price_in_cents":0,"trial_interval":14,"trial_interval_unit":"day","archived_at":null,"require_credit_card":false,"return_params":"","taxable":false,"update_return_url":"","tax_code":"","initial_charge_after_trial":false,"version_number":1,"update_return_params":"","default_product_price_point_id":2245073,"request_billing_address":false,"require_billing_address":false,"require_shipping_address":false,"use_site_exchange_rate":true,"item_category":null,"product_price_point_id":2245073,"product_price_point_name":"New
         Price May 2021","product_price_point_handle":"uuid:71f899e0-8c25-0139-8dc8-0a575a757c23","product_family":{"id":2473952,"name":"Blinkbid
         - USA","description":"Blinkbid software sold in the United States, in USD
-        currency.","handle":"blinkbid-usa","accounting_code":null,"created_at":"2022-12-15T06:06:29-08:00","updated_at":"2022-12-15T06:06:29-08:00"},"public_signup_pages":[]},"credit_card":{"id":60069023,"first_name":"Johnn","last_name":"Doeee","masked_card_number":"XXXX-XXXX-XXXX-1111","card_type":"visa","expiration_month":7,"expiration_year":2033,"customer_id":81125010,"current_vault":"bogus","vault_token":"1","billing_address":"Los
-        Angeles","billing_city":"LA","billing_state":"AK","billing_zip":"1212121212","billing_country":"US","customer_vault_token":null,"billing_address_2":null,"payment_type":"credit_card","disabled":false,"site_gateway_setting_id":null,"gateway_handle":null}}}'
-  recorded_at: Fri, 12 Jul 2024 17:42:13 GMT
+        currency.","handle":"blinkbid-usa","accounting_code":null,"created_at":"2022-12-15T06:06:29-08:00","updated_at":"2022-12-15T06:06:29-08:00"},"public_signup_pages":[]},"credit_card":{"id":60180134,"first_name":"Johnn","last_name":"Doeee","masked_card_number":"XXXX-XXXX-XXXX-1111","card_type":"visa","expiration_month":4,"expiration_year":2030,"customer_id":81446471,"current_vault":"bogus","vault_token":"1","billing_address":"Los
+        Angeles","billing_city":"LA","billing_state":"AL","billing_zip":"1212121212","billing_country":"US","customer_vault_token":null,"billing_address_2":null,"payment_type":"credit_card","disabled":false,"site_gateway_setting_id":null,"gateway_handle":null}}}'
+  recorded_at: Fri, 19 Jul 2024 15:49:08 GMT
 recorded_with: VCR 6.2.0

--- a/spec/fixtures/cassettes/chargify_wrapper/subscription_reactivate/when_subscription_is_on_trial_ended_state_returns_http_status_200.yml
+++ b/spec/fixtures/cassettes/chargify_wrapper/subscription_reactivate/when_subscription_is_on_trial_ended_state_returns_http_status_200.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://<CHARGIFY_SUBDOMAIN>.chargify.com/subscriptions/77228697.json
+    uri: https://<CHARGIFY_SUBDOMAIN>.chargify.com/subscriptions/77390750.json
     body:
       encoding: US-ASCII
       string: ''
@@ -25,9 +25,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 12 Jul 2024 17:42:04 GMT
+      - Fri, 19 Jul 2024 15:48:59 GMT
       Etag:
-      - W/"97e2356a7eb4ef89b7c3c6987778db6e"
+      - W/"6683298eba7235af05cbb547f1a8e0ec"
       Referrer-Policy:
       - strict-origin-when-cross-origin
       Server:
@@ -47,9 +47,9 @@ http_interactions:
       X-Powered-By:
       - Phusion Passenger(R) Enterprise
       X-Request-Id:
-      - fdb62a4f-dc9a-4c6c-8049-28cf26b9f970
+      - 344dd989-7e61-4f7c-8fcb-9a2f5d298424
       X-Runtime:
-      - '0.098925'
+      - '0.141236'
       X-Xss-Protection:
       - 1; mode=block
       Transfer-Encoding:
@@ -58,16 +58,17 @@ http_interactions:
       - keep-alive
     body:
       encoding: UTF-8
-      string: '{"subscription":{"id":77228697,"state":"active","trial_started_at":"2024-07-12T07:06:12-07:00","trial_ended_at":"2024-07-12T07:10:00-07:00","activated_at":"2024-07-12T09:14:12-07:00","created_at":"2024-07-12T07:06:12-07:00","updated_at":"2024-07-12T09:14:12-07:00","expires_at":null,"balance_in_cents":0,"current_period_ends_at":"2025-07-12T09:14:12-07:00","next_assessment_at":"2025-07-12T09:14:12-07:00","canceled_at":null,"cancellation_message":null,"next_product_id":null,"next_product_handle":null,"cancel_at_end_of_period":false,"payment_collection_method":"automatic","snap_day":null,"cancellation_method":null,"current_period_started_at":"2024-07-12T09:14:12-07:00","previous_state":"trial_ended","signup_payment_id":1110911377,"signup_revenue":"0.00","delayed_cancel_at":null,"coupon_code":null,"total_revenue_in_cents":28800,"product_price_in_cents":28800,"product_version_number":1,"payment_type":"credit_card","referral_code":null,"coupon_use_count":null,"coupon_uses_allowed":null,"reason_code":null,"automatically_resume_at":null,"coupon_codes":[],"offer_id":null,"payer_id":null,"receives_invoice_emails":null,"product_price_point_id":2245073,"next_product_price_point_id":null,"net_terms":null,"stored_credential_transaction_id":null,"reference":null,"currency":"USD","on_hold_at":null,"scheduled_cancellation_at":null,"product_price_point_type":"default","dunning_communication_delay_enabled":false,"dunning_communication_delay_time_zone":null,"current_billing_amount_in_cents":28800,"customer":{"id":81125010,"first_name":"Luana","last_name":"8","organization":null,"email":"ls8@gmail.com","created_at":"2024-07-12T07:06:12-07:00","updated_at":"2024-07-12T07:06:12-07:00","reference":null,"address":null,"address_2":null,"city":null,"state":null,"state_name":null,"zip":null,"country":null,"country_name":null,"phone":null,"portal_invite_last_sent_at":null,"portal_invite_last_accepted_at":null,"verified":false,"portal_customer_created_at":null,"vat_number":null,"cc_emails":null,"tax_exempt":false,"parent_id":null},"product":{"id":6388932,"name":"Solo","handle":"solo-annual-trial","description":"Users:
+      string: '{"subscription":{"id":77390750,"state":"trial_ended","trial_started_at":"2024-07-19T06:08:04-07:00","trial_ended_at":"2024-07-19T06:15:00-07:00","activated_at":null,"created_at":"2024-07-19T06:08:04-07:00","updated_at":"2024-07-19T08:44:57-07:00","expires_at":null,"balance_in_cents":0,"current_period_ends_at":null,"next_assessment_at":null,"canceled_at":null,"cancellation_message":"Trial
+        ended on 19 Jul 2024 6:15 AM PDT with no card on file","next_product_id":null,"next_product_handle":null,"cancel_at_end_of_period":false,"payment_collection_method":"automatic","snap_day":null,"cancellation_method":null,"current_period_started_at":null,"previous_state":"trialing","signup_payment_id":1114690124,"signup_revenue":"0.00","delayed_cancel_at":null,"coupon_code":null,"total_revenue_in_cents":0,"product_price_in_cents":28800,"product_version_number":1,"payment_type":"credit_card","referral_code":null,"coupon_use_count":null,"coupon_uses_allowed":null,"reason_code":null,"automatically_resume_at":null,"coupon_codes":[],"offer_id":null,"payer_id":null,"receives_invoice_emails":null,"product_price_point_id":2245073,"next_product_price_point_id":null,"net_terms":null,"stored_credential_transaction_id":null,"reference":null,"currency":"USD","on_hold_at":null,"scheduled_cancellation_at":null,"product_price_point_type":"default","dunning_communication_delay_enabled":false,"dunning_communication_delay_time_zone":null,"current_billing_amount_in_cents":28800,"customer":{"id":81446471,"first_name":"Luana","last_name":"3","organization":null,"email":"a3@gmail.com","created_at":"2024-07-19T06:08:04-07:00","updated_at":"2024-07-19T06:08:04-07:00","reference":null,"address":null,"address_2":null,"city":null,"state":null,"state_name":null,"zip":null,"country":null,"country_name":null,"phone":null,"portal_invite_last_sent_at":null,"portal_invite_last_accepted_at":null,"verified":false,"portal_customer_created_at":null,"vat_number":null,"cc_emails":null,"tax_exempt":false,"parent_id":null},"product":{"id":6388932,"name":"Solo","handle":"solo-annual-trial","description":"Users:
         1\r\nPersonalities: 10","accounting_code":"11","request_credit_card":true,"expiration_interval":null,"expiration_interval_unit":"never","created_at":"2022-12-15T06:06:31-08:00","updated_at":"2024-07-01T10:16:15-07:00","price_in_cents":28800,"interval":12,"interval_unit":"month","initial_charge_in_cents":null,"trial_price_in_cents":0,"trial_interval":14,"trial_interval_unit":"day","archived_at":null,"require_credit_card":false,"return_params":"","taxable":false,"update_return_url":"","tax_code":"","initial_charge_after_trial":false,"version_number":1,"update_return_params":"","default_product_price_point_id":2245073,"request_billing_address":false,"require_billing_address":false,"require_shipping_address":false,"use_site_exchange_rate":true,"item_category":null,"product_price_point_id":2245073,"product_price_point_name":"New
         Price May 2021","product_price_point_handle":"uuid:71f899e0-8c25-0139-8dc8-0a575a757c23","product_family":{"id":2473952,"name":"Blinkbid
         - USA","description":"Blinkbid software sold in the United States, in USD
-        currency.","handle":"blinkbid-usa","accounting_code":null,"created_at":"2022-12-15T06:06:29-08:00","updated_at":"2022-12-15T06:06:29-08:00"},"public_signup_pages":[]},"credit_card":{"id":60069023,"first_name":"Johnn","last_name":"Doeee","masked_card_number":"XXXX-XXXX-XXXX-1111","card_type":"visa","expiration_month":7,"expiration_year":2033,"customer_id":81125010,"current_vault":"bogus","vault_token":"1","billing_address":"Los
-        Angeles","billing_city":"LA","billing_state":"AK","billing_zip":"1212121212","billing_country":"US","customer_vault_token":null,"billing_address_2":null,"payment_type":"credit_card","disabled":false,"site_gateway_setting_id":null,"gateway_handle":null}}}'
-  recorded_at: Fri, 12 Jul 2024 17:42:10 GMT
+        currency.","handle":"blinkbid-usa","accounting_code":null,"created_at":"2022-12-15T06:06:29-08:00","updated_at":"2022-12-15T06:06:29-08:00"},"public_signup_pages":[]},"credit_card":{"id":60180134,"first_name":"Johnn","last_name":"Doeee","masked_card_number":"XXXX-XXXX-XXXX-1111","card_type":"visa","expiration_month":4,"expiration_year":2030,"customer_id":81446471,"current_vault":"bogus","vault_token":"1","billing_address":"Los
+        Angeles","billing_city":"LA","billing_state":"AL","billing_zip":"1212121212","billing_country":"US","customer_vault_token":null,"billing_address_2":null,"payment_type":"credit_card","disabled":false,"site_gateway_setting_id":null,"gateway_handle":null}}}'
+  recorded_at: Fri, 19 Jul 2024 15:49:04 GMT
 - request:
     method: put
-    uri: https://<CHARGIFY_SUBDOMAIN>.chargify.com/subscriptions/77228697/reactivate.json
+    uri: https://<CHARGIFY_SUBDOMAIN>.chargify.com/subscriptions/77390750/reactivate.json
     body:
       encoding: UTF-8
       string: "{}"
@@ -84,21 +85,27 @@ http_interactions:
       - Ruby
   response:
     status:
-      code: 422
-      message: Unprocessable Entity
+      code: 200
+      message: OK
     headers:
       Cache-Control:
       - private, no-store
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 12 Jul 2024 17:42:05 GMT
+      - Fri, 19 Jul 2024 15:49:01 GMT
+      Etag:
+      - W/"91a15b2ec8cf2213f3fe6583cd938fca"
+      Location:
+      - https://<CHARGIFY_SUBDOMAIN>.chargify.com/subscriptions/77390750
       Referrer-Policy:
       - strict-origin-when-cross-origin
       Server:
       - nginx + Phusion Passenger(R)
       Status:
-      - 422 Unprocessable Entity
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=31536000
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -110,18 +117,22 @@ http_interactions:
       X-Powered-By:
       - Phusion Passenger(R) Enterprise
       X-Request-Id:
-      - 9c27d405-9fe9-4fb7-8c3d-0dd07569de69
+      - 0bc3c089-5e53-4507-aae5-3022935da857
       X-Runtime:
-      - '0.073580'
+      - '0.759070'
       X-Xss-Protection:
       - 1; mode=block
-      Transfer-Encoding:
-      - chunked
+      Content-Length:
+      - '3666'
       Connection:
       - keep-alive
     body:
       encoding: UTF-8
-      string: '{"errors":["Cannot reactivate a subscription that is not marked \"Canceled\"
-        or \"Trial Ended\"."]}'
-  recorded_at: Fri, 12 Jul 2024 17:42:11 GMT
+      string: '{"subscription":{"id":77390750,"state":"active","trial_started_at":"2024-07-19T06:08:04-07:00","trial_ended_at":"2024-07-19T06:15:00-07:00","activated_at":"2024-07-19T08:49:00-07:00","created_at":"2024-07-19T06:08:04-07:00","updated_at":"2024-07-19T08:49:00-07:00","expires_at":null,"balance_in_cents":0,"current_period_ends_at":"2025-07-19T08:49:00-07:00","next_assessment_at":"2025-07-19T08:49:00-07:00","canceled_at":null,"cancellation_message":null,"next_product_id":null,"cancel_at_end_of_period":false,"payment_collection_method":"automatic","snap_day":null,"cancellation_method":null,"product_price_point_id":2245073,"next_product_price_point_id":null,"receives_invoice_emails":null,"net_terms":null,"currency":"USD","reference":null,"scheduled_cancellation_at":null,"current_period_started_at":"2024-07-19T08:49:00-07:00","previous_state":"trial_ended","signup_payment_id":1114690124,"signup_revenue":"0.00","delayed_cancel_at":null,"coupon_code":null,"total_revenue_in_cents":28800,"product_price_in_cents":28800,"product_version_number":1,"payment_type":"credit_card","referral_code":null,"coupon_use_count":null,"coupon_uses_allowed":null,"reason_code":null,"automatically_resume_at":null,"coupon_codes":[],"offer_id":null,"payer_id":null,"stored_credential_transaction_id":null,"next_product_handle":null,"on_hold_at":null,"customer":{"id":81446471,"first_name":"Luana","last_name":"3","organization":null,"email":"a3@gmail.com","created_at":"2024-07-19T06:08:04-07:00","updated_at":"2024-07-19T06:08:04-07:00","reference":null,"address":null,"address_2":null,"city":null,"state":null,"zip":null,"country":null,"phone":null,"portal_invite_last_sent_at":null,"portal_invite_last_accepted_at":null,"verified":false,"portal_customer_created_at":null,"vat_number":null,"cc_emails":null,"tax_exempt":false,"parent_id":null,"locale":null},"product":{"id":6388932,"name":"Solo","handle":"solo-annual-trial","description":"Users:
+        1\r\nPersonalities: 10","accounting_code":"11","request_credit_card":true,"expiration_interval":null,"expiration_interval_unit":"never","created_at":"2022-12-15T06:06:31-08:00","updated_at":"2024-07-01T10:16:15-07:00","price_in_cents":28800,"interval":12,"interval_unit":"month","initial_charge_in_cents":null,"trial_price_in_cents":0,"trial_interval":14,"trial_interval_unit":"day","archived_at":null,"require_credit_card":false,"return_params":"","require_shipping_address":false,"request_billing_address":false,"require_billing_address":false,"taxable":false,"update_return_url":"","tax_code":"","initial_charge_after_trial":false,"default_product_price_point_id":2245073,"item_category":null,"version_number":1,"update_return_params":"","product_price_point_id":2245073,"product_price_point_name":"New
+        Price May 2021","product_price_point_handle":"uuid:71f899e0-8c25-0139-8dc8-0a575a757c23","use_site_exchange_rate":true,"product_family":{"id":2473952,"name":"Blinkbid
+        - USA","description":"Blinkbid software sold in the United States, in USD
+        currency.","handle":"blinkbid-usa","accounting_code":null,"created_at":"2022-12-15T06:06:29-08:00","updated_at":"2022-12-15T06:06:29-08:00"},"public_signup_pages":[]},"credit_card":{"id":60180134,"first_name":"Johnn","last_name":"Doeee","masked_card_number":"XXXX-XXXX-XXXX-1111","card_type":"visa","expiration_month":4,"expiration_year":2030,"customer_id":81446471,"current_vault":"bogus","vault_token":"1","billing_address":"Los
+        Angeles","billing_city":"LA","billing_state":"AL","billing_zip":"1212121212","billing_country":"US","customer_vault_token":null,"billing_address_2":null,"site_gateway_setting_id":null,"payment_type":"credit_card","disabled":false,"gateway_handle":null}}}'
+  recorded_at: Fri, 19 Jul 2024 15:49:06 GMT
 recorded_with: VCR 6.2.0

--- a/spec/fixtures/cassettes/chargify_wrapper/subscription_reactivate/when_the_call_is_sent_with_parameters_sends_the_request_correctly.yml
+++ b/spec/fixtures/cassettes/chargify_wrapper/subscription_reactivate/when_the_call_is_sent_with_parameters_sends_the_request_correctly.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://<CHARGIFY_SUBDOMAIN>.chargify.com/subscriptions/77228728.json
+    uri: https://<CHARGIFY_SUBDOMAIN>.chargify.com/subscriptions/77390759.json
     body:
       encoding: US-ASCII
       string: ''
@@ -25,9 +25,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 12 Jul 2024 17:42:08 GMT
+      - Fri, 19 Jul 2024 15:49:04 GMT
       Etag:
-      - W/"5866c3358b82a64dd3e16e486cea603c"
+      - W/"f35f649b28ed8f0ea1fb872905f88fda"
       Referrer-Policy:
       - strict-origin-when-cross-origin
       Server:
@@ -47,9 +47,9 @@ http_interactions:
       X-Powered-By:
       - Phusion Passenger(R) Enterprise
       X-Request-Id:
-      - 0541ac56-87c3-4978-8ffb-8144b9f52afd
+      - 6839bf9b-3705-4a08-94ae-56adac5410f1
       X-Runtime:
-      - '0.096185'
+      - '0.147836'
       X-Xss-Protection:
       - 1; mode=block
       Transfer-Encoding:
@@ -58,16 +58,17 @@ http_interactions:
       - keep-alive
     body:
       encoding: UTF-8
-      string: '{"subscription":{"id":77228728,"state":"trialing","trial_started_at":"2024-07-12T09:19:15-07:00","trial_ended_at":"2024-07-26T09:19:15-07:00","activated_at":null,"created_at":"2024-07-12T07:06:48-07:00","updated_at":"2024-07-12T09:19:15-07:00","expires_at":null,"balance_in_cents":0,"current_period_ends_at":"2024-07-26T09:19:15-07:00","next_assessment_at":"2024-07-26T09:19:15-07:00","canceled_at":null,"cancellation_message":null,"next_product_id":null,"next_product_handle":null,"cancel_at_end_of_period":false,"payment_collection_method":"automatic","snap_day":null,"cancellation_method":null,"current_period_started_at":"2024-07-12T09:19:15-07:00","previous_state":"trial_ended","signup_payment_id":1110911452,"signup_revenue":"0.00","delayed_cancel_at":null,"coupon_code":null,"total_revenue_in_cents":0,"product_price_in_cents":28800,"product_version_number":1,"payment_type":"credit_card","referral_code":null,"coupon_use_count":null,"coupon_uses_allowed":null,"reason_code":null,"automatically_resume_at":null,"coupon_codes":[],"offer_id":null,"payer_id":null,"receives_invoice_emails":null,"product_price_point_id":2245073,"next_product_price_point_id":null,"net_terms":null,"stored_credential_transaction_id":null,"reference":null,"currency":"USD","on_hold_at":null,"scheduled_cancellation_at":null,"product_price_point_type":"default","dunning_communication_delay_enabled":false,"dunning_communication_delay_time_zone":null,"current_billing_amount_in_cents":28800,"customer":{"id":81125041,"first_name":"Luana","last_name":"9","organization":null,"email":"ls9@gmail.com","created_at":"2024-07-12T07:06:48-07:00","updated_at":"2024-07-12T07:06:48-07:00","reference":null,"address":null,"address_2":null,"city":null,"state":null,"state_name":null,"zip":null,"country":null,"country_name":null,"phone":null,"portal_invite_last_sent_at":null,"portal_invite_last_accepted_at":null,"verified":false,"portal_customer_created_at":null,"vat_number":null,"cc_emails":null,"tax_exempt":false,"parent_id":null},"product":{"id":6388932,"name":"Solo","handle":"solo-annual-trial","description":"Users:
+      string: '{"subscription":{"id":77390759,"state":"trial_ended","trial_started_at":"2024-07-19T06:08:49-07:00","trial_ended_at":"2024-07-19T06:16:00-07:00","activated_at":null,"created_at":"2024-07-19T06:08:49-07:00","updated_at":"2024-07-19T08:46:51-07:00","expires_at":null,"balance_in_cents":0,"current_period_ends_at":null,"next_assessment_at":null,"canceled_at":null,"cancellation_message":"Trial
+        ended on 19 Jul 2024 6:16 AM PDT with no card on file","next_product_id":null,"next_product_handle":null,"cancel_at_end_of_period":false,"payment_collection_method":"automatic","snap_day":null,"cancellation_method":null,"current_period_started_at":null,"previous_state":"trialing","signup_payment_id":1114690171,"signup_revenue":"0.00","delayed_cancel_at":null,"coupon_code":null,"total_revenue_in_cents":0,"product_price_in_cents":28800,"product_version_number":1,"payment_type":"credit_card","referral_code":null,"coupon_use_count":null,"coupon_uses_allowed":null,"reason_code":null,"automatically_resume_at":null,"coupon_codes":[],"offer_id":null,"payer_id":null,"receives_invoice_emails":null,"product_price_point_id":2245073,"next_product_price_point_id":null,"net_terms":null,"stored_credential_transaction_id":null,"reference":null,"currency":"USD","on_hold_at":null,"scheduled_cancellation_at":null,"product_price_point_type":"default","dunning_communication_delay_enabled":false,"dunning_communication_delay_time_zone":null,"current_billing_amount_in_cents":28800,"customer":{"id":81446478,"first_name":"Luana","last_name":"4","organization":null,"email":"a4@gmail.com","created_at":"2024-07-19T06:08:49-07:00","updated_at":"2024-07-19T06:08:49-07:00","reference":null,"address":null,"address_2":null,"city":null,"state":null,"state_name":null,"zip":null,"country":null,"country_name":null,"phone":null,"portal_invite_last_sent_at":null,"portal_invite_last_accepted_at":null,"verified":false,"portal_customer_created_at":null,"vat_number":null,"cc_emails":null,"tax_exempt":false,"parent_id":null},"product":{"id":6388932,"name":"Solo","handle":"solo-annual-trial","description":"Users:
         1\r\nPersonalities: 10","accounting_code":"11","request_credit_card":true,"expiration_interval":null,"expiration_interval_unit":"never","created_at":"2022-12-15T06:06:31-08:00","updated_at":"2024-07-01T10:16:15-07:00","price_in_cents":28800,"interval":12,"interval_unit":"month","initial_charge_in_cents":null,"trial_price_in_cents":0,"trial_interval":14,"trial_interval_unit":"day","archived_at":null,"require_credit_card":false,"return_params":"","taxable":false,"update_return_url":"","tax_code":"","initial_charge_after_trial":false,"version_number":1,"update_return_params":"","default_product_price_point_id":2245073,"request_billing_address":false,"require_billing_address":false,"require_shipping_address":false,"use_site_exchange_rate":true,"item_category":null,"product_price_point_id":2245073,"product_price_point_name":"New
         Price May 2021","product_price_point_handle":"uuid:71f899e0-8c25-0139-8dc8-0a575a757c23","product_family":{"id":2473952,"name":"Blinkbid
         - USA","description":"Blinkbid software sold in the United States, in USD
-        currency.","handle":"blinkbid-usa","accounting_code":null,"created_at":"2022-12-15T06:06:29-08:00","updated_at":"2022-12-15T06:06:29-08:00"},"public_signup_pages":[]},"credit_card":{"id":60069205,"first_name":"Johnn","last_name":"Doeee","masked_card_number":"XXXX-XXXX-XXXX-1111","card_type":"visa","expiration_month":5,"expiration_year":2031,"customer_id":81125041,"current_vault":"bogus","vault_token":"1","billing_address":"Los
-        Angeles","billing_city":"LA","billing_state":"ABE","billing_zip":"1212121212","billing_country":"GB","customer_vault_token":null,"billing_address_2":null,"payment_type":"credit_card","disabled":false,"site_gateway_setting_id":null,"gateway_handle":null}}}'
-  recorded_at: Fri, 12 Jul 2024 17:42:14 GMT
+        currency.","handle":"blinkbid-usa","accounting_code":null,"created_at":"2022-12-15T06:06:29-08:00","updated_at":"2022-12-15T06:06:29-08:00"},"public_signup_pages":[]},"credit_card":{"id":60180166,"first_name":"Johnn","last_name":"Doeee","masked_card_number":"XXXX-XXXX-XXXX-1111","card_type":"visa","expiration_month":4,"expiration_year":2028,"customer_id":81446478,"current_vault":"bogus","vault_token":"1","billing_address":"Los
+        Angeles","billing_city":"LA","billing_state":"AL","billing_zip":"1212121212","billing_country":"US","customer_vault_token":null,"billing_address_2":null,"payment_type":"credit_card","disabled":false,"site_gateway_setting_id":null,"gateway_handle":null}}}'
+  recorded_at: Fri, 19 Jul 2024 15:49:09 GMT
 - request:
     method: put
-    uri: https://<CHARGIFY_SUBDOMAIN>.chargify.com/subscriptions/77228728/reactivate.json
+    uri: https://<CHARGIFY_SUBDOMAIN>.chargify.com/subscriptions/77390759/reactivate.json
     body:
       encoding: UTF-8
       string: '{"include_trial":true,"preserve_balance":true,"coupon_code":"10OFF","use_credits_and_prepayments":true,"resume":true}'
@@ -84,21 +85,27 @@ http_interactions:
       - Ruby
   response:
     status:
-      code: 422
-      message: Unprocessable Entity
+      code: 200
+      message: OK
     headers:
       Cache-Control:
       - private, no-store
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 12 Jul 2024 17:42:09 GMT
+      - Fri, 19 Jul 2024 15:49:05 GMT
+      Etag:
+      - W/"ecbb904391e15f8318f95c6c4dfa7107"
+      Location:
+      - https://<CHARGIFY_SUBDOMAIN>.chargify.com/subscriptions/77390759
       Referrer-Policy:
       - strict-origin-when-cross-origin
       Server:
       - nginx + Phusion Passenger(R)
       Status:
-      - 422 Unprocessable Entity
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=31536000
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -110,18 +117,22 @@ http_interactions:
       X-Powered-By:
       - Phusion Passenger(R) Enterprise
       X-Request-Id:
-      - 3897b18d-e597-4619-a1fd-83d88f1e0838
+      - 92922f1d-d111-46a6-a0f4-6fbdd768b595
       X-Runtime:
-      - '0.064301'
+      - '0.438412'
       X-Xss-Protection:
       - 1; mode=block
       Content-Length:
-      - '99'
+      - '3641'
       Connection:
       - keep-alive
     body:
       encoding: UTF-8
-      string: '{"errors":["Cannot reactivate a subscription that is not marked \"Canceled\"
-        or \"Trial Ended\"."]}'
-  recorded_at: Fri, 12 Jul 2024 17:42:15 GMT
+      string: '{"subscription":{"id":77390759,"state":"trialing","trial_started_at":"2024-07-19T08:49:05-07:00","trial_ended_at":"2024-08-02T08:49:05-07:00","activated_at":null,"created_at":"2024-07-19T06:08:49-07:00","updated_at":"2024-07-19T08:49:05-07:00","expires_at":null,"balance_in_cents":0,"current_period_ends_at":"2024-08-02T08:49:05-07:00","next_assessment_at":"2024-08-02T08:49:05-07:00","canceled_at":null,"cancellation_message":null,"next_product_id":null,"cancel_at_end_of_period":false,"payment_collection_method":"automatic","snap_day":null,"cancellation_method":null,"product_price_point_id":2245073,"next_product_price_point_id":null,"receives_invoice_emails":null,"net_terms":null,"currency":"USD","reference":null,"scheduled_cancellation_at":null,"current_period_started_at":"2024-07-19T08:49:05-07:00","previous_state":"trial_ended","signup_payment_id":1114690171,"signup_revenue":"0.00","delayed_cancel_at":null,"coupon_code":null,"total_revenue_in_cents":0,"product_price_in_cents":28800,"product_version_number":1,"payment_type":"credit_card","referral_code":null,"coupon_use_count":null,"coupon_uses_allowed":null,"reason_code":null,"automatically_resume_at":null,"coupon_codes":[],"offer_id":null,"payer_id":null,"stored_credential_transaction_id":null,"next_product_handle":null,"on_hold_at":null,"customer":{"id":81446478,"first_name":"Luana","last_name":"4","organization":null,"email":"a4@gmail.com","created_at":"2024-07-19T06:08:49-07:00","updated_at":"2024-07-19T06:08:49-07:00","reference":null,"address":null,"address_2":null,"city":null,"state":null,"zip":null,"country":null,"phone":null,"portal_invite_last_sent_at":null,"portal_invite_last_accepted_at":null,"verified":false,"portal_customer_created_at":null,"vat_number":null,"cc_emails":null,"tax_exempt":false,"parent_id":null,"locale":null},"product":{"id":6388932,"name":"Solo","handle":"solo-annual-trial","description":"Users:
+        1\r\nPersonalities: 10","accounting_code":"11","request_credit_card":true,"expiration_interval":null,"expiration_interval_unit":"never","created_at":"2022-12-15T06:06:31-08:00","updated_at":"2024-07-01T10:16:15-07:00","price_in_cents":28800,"interval":12,"interval_unit":"month","initial_charge_in_cents":null,"trial_price_in_cents":0,"trial_interval":14,"trial_interval_unit":"day","archived_at":null,"require_credit_card":false,"return_params":"","require_shipping_address":false,"request_billing_address":false,"require_billing_address":false,"taxable":false,"update_return_url":"","tax_code":"","initial_charge_after_trial":false,"default_product_price_point_id":2245073,"item_category":null,"version_number":1,"update_return_params":"","product_price_point_id":2245073,"product_price_point_name":"New
+        Price May 2021","product_price_point_handle":"uuid:71f899e0-8c25-0139-8dc8-0a575a757c23","use_site_exchange_rate":true,"product_family":{"id":2473952,"name":"Blinkbid
+        - USA","description":"Blinkbid software sold in the United States, in USD
+        currency.","handle":"blinkbid-usa","accounting_code":null,"created_at":"2022-12-15T06:06:29-08:00","updated_at":"2022-12-15T06:06:29-08:00"},"public_signup_pages":[]},"credit_card":{"id":60180166,"first_name":"Johnn","last_name":"Doeee","masked_card_number":"XXXX-XXXX-XXXX-1111","card_type":"visa","expiration_month":4,"expiration_year":2028,"customer_id":81446478,"current_vault":"bogus","vault_token":"1","billing_address":"Los
+        Angeles","billing_city":"LA","billing_state":"AL","billing_zip":"1212121212","billing_country":"US","customer_vault_token":null,"billing_address_2":null,"site_gateway_setting_id":null,"payment_type":"credit_card","disabled":false,"gateway_handle":null}}}'
+  recorded_at: Fri, 19 Jul 2024 15:49:11 GMT
 recorded_with: VCR 6.2.0

--- a/spec/resources/subscription_spec.rb
+++ b/spec/resources/subscription_spec.rb
@@ -145,7 +145,7 @@ RSpec.describe ChargifyWrapper::Subscription do
     context "when reactivation fails" do
       let(:subscription) { described_class.find(76900225) }
 
-      it { expect{ reactivate_subscription }.to raise_error(ActiveResource::ResourceInvalid) }
+      it { expect { reactivate_subscription }.to raise_error(ActiveResource::ResourceInvalid) }
     end
   end
 end

--- a/spec/resources/subscription_spec.rb
+++ b/spec/resources/subscription_spec.rb
@@ -106,7 +106,7 @@ RSpec.describe ChargifyWrapper::Subscription do
     let(:url_matcher) { Regexp.new(".chargify.com/subscriptions/#{subscription.id}/reactivate.json") }
 
     context "when subscription is on trial_ended state" do
-      let(:subscription) { described_class.find(77228697) }
+      let(:subscription) { described_class.find(77390750) }
 
       it "returns http status 200" do
         reactivate_subscription
@@ -120,7 +120,7 @@ RSpec.describe ChargifyWrapper::Subscription do
     end
 
     context "when the call is sent with parameters" do
-      let(:subscription) { described_class.find(77228728) }
+      let(:subscription) { described_class.find(77390759) }
 
       it "sends the request correctly" do
         subscription.reactivate(
@@ -143,9 +143,9 @@ RSpec.describe ChargifyWrapper::Subscription do
     end
 
     context "when reactivation fails" do
-      let(:subscription) { described_class.find(77228576) }
+      let(:subscription) { described_class.find(76900225) }
 
-      it { expect([subscription.errors.full_messages]).not_to be_empty }
+      it { expect{ reactivate_subscription }.to raise_error(ActiveResource::ResourceInvalid) }
     end
   end
 end


### PR DESCRIPTION
N/A

### Feature
This pr removes the gem's error handling method so that we can handle the error response on the side of the application that will be using the gem

### Setup
Install the gem on your local env
```bash
gem uninstall --force chargify_wrapper
gem build chargify_wrapper.gemspec --output=chargify_wrapper.gem
gem install chargify_wrapper --local chargify_wrapper.gem
```

### Q & A
You must test with a active subscription
Open an `irb` console
Require the gem and configure it
```ruby
require 'chargify_wrapper'
ChargifyWrapper.configure do |config|
  config.subdomain = SUBDOMAIN
  config.api_key = API_KEY
  config.log_requests = true
end
```
Call the method that sends the request to chargify:
```ruby
ChargifyWrapper::Subscription.find(<SUBSCRIPTION_ID>).reactivate
```
- The return **should be the response with the ResourceInvalid error raised by Active Resource**