### PR TITLE
feat(validate-coupon): return coupon object on validate method

### DIFF
--- a/lib/chargify_wrapper/resources/coupon.rb
+++ b/lib/chargify_wrapper/resources/coupon.rb
@@ -5,10 +5,9 @@ module ChargifyWrapper
     class << self
       def validate(code, product_family_id: nil)
         params = {code: code}
-
         params[:product_family_id] = product_family_id if product_family_id
 
-        get(:validate, params)
+        find(:one, from: :validate, params: params)
       end
     end
   end

--- a/spec/resources/coupon_spec.rb
+++ b/spec/resources/coupon_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe ChargifyWrapper::Coupon do
     context "when coupon is existent and valid" do
       let(:coupon) { "GENERALCOUPON" }
 
-      it { expect(validate_coupon).to be_present }
+      it { expect(validate_coupon).to be_a(described_class) }
     end
 
     context "when coupon is not existent" do


### PR DESCRIPTION
[BB-1287](https://87labs.atlassian.net/browse/BB-1287)

### Feature

The `#validate` method on `ChargifyWrapper::Coupon` was made as a class method, since it does not require a coupon to work. Because of that, the `get` method used inside the `#validate` was returning a hash, which does not follow other similar methods, like `find` or `update`.

In order to keep a consistency between methods, the `get(:validate, ...)` got replaced by `find(:one, from: :validate, ...)`, which makes the same request to `GET /coupons/validate?code=XXXX`, but returning a `ChargifyWrapper::Coupon` object instead of a hash

### Setup

Uninstall, build and install the gem
```
gem uninstall --force chargify_wrapper
gem build chargify_wrapper.gemspec --output=chargify.gem
gem install chargify_wrapper --local chargify.gem
```

### Q & A

Open an irb and configure the gem
```
require 'chargify_wrapper'

ChargifyWrapper.configure do |config|
  config.subdomain = 'your-subdomain'
  config.api_key = 'your-api-key'
  config.log_requests = true
end
```

Try to find a valid coupon with `ChargifyWrapper::Coupon.validate(....)`
It should return the coupon object instead of a hash

Try to find a valid coupon with a different product_family `ChargifyWrapper::Coupon.validate(.... , product_family_id: 1)`
It should raise an 404 error

Try to find an invalid coupon with `ChargifyWrapper::Coupon.validate(....)`
It should raise an 404 error
