### PR TITLE
feat(dependencies): adjust rails dependencies versions to ~> 6.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,16 +2,16 @@ PATH
   remote: .
   specs:
     chargify_wrapper (0.5.3)
-      activemodel (= 6.1.7.7)
+      activemodel (~> 6.1)
       activeresource (~> 6.1.0)
-      activesupport (= 6.1.7.7)
+      activesupport (~> 6.1)
       httplog (~> 1.6.3)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (6.1.7.7)
-      activesupport (= 6.1.7.7)
+    activemodel (6.1.7.8)
+      activesupport (= 6.1.7.8)
     activemodel-serializers-xml (1.0.2)
       activemodel (> 5.x)
       activesupport (> 5.x)
@@ -20,7 +20,7 @@ GEM
       activemodel (>= 6.0)
       activemodel-serializers-xml (~> 1.0)
       activesupport (>= 6.0)
-    activesupport (6.1.7.7)
+    activesupport (6.1.7.8)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
@@ -30,7 +30,7 @@ GEM
       public_suffix (>= 2.0.2, < 6.0)
     ast (2.4.2)
     builder (3.3.0)
-    concurrent-ruby (1.3.3)
+    concurrent-ruby (1.3.4)
     crack (0.4.5)
       rexml
     diff-lcs (1.5.0)
@@ -39,12 +39,12 @@ GEM
     httplog (1.6.3)
       rack (>= 2.0)
       rainbow (>= 2.0.0)
-    i18n (1.14.5)
+    i18n (1.14.6)
       concurrent-ruby (~> 1.0)
     json (2.6.3)
     language_server-protocol (3.17.0.3)
     lint_roller (1.1.0)
-    minitest (5.24.1)
+    minitest (5.25.1)
     parallel (1.23.0)
     parser (3.2.2.3)
       ast (~> 2.4.1)
@@ -115,7 +115,7 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    zeitwerk (2.6.16)
+    zeitwerk (2.6.18)
 
 PLATFORMS
   ruby

--- a/chargify_wrapper.gemspec
+++ b/chargify_wrapper.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency("rubocop-performance", "~> 1.18")
   spec.add_development_dependency("rubocop-rspec", "~> 2.23")
   spec.add_runtime_dependency("httplog", "~> 1.6.3")
-  spec.add_runtime_dependency("activemodel", "= 6.1.7.7")
-  spec.add_runtime_dependency("activesupport", "= 6.1.7.7")
+  spec.add_runtime_dependency("activemodel", "~> 6.1")
+  spec.add_runtime_dependency("activesupport", "~> 6.1")
   spec.add_runtime_dependency("activeresource", "~> 6.1.0")
 end


### PR DESCRIPTION
[BB-1367](https://87labs.atlassian.net/browse/BB-1367)

### Feature

fix versions of `activesupport` and `activemodel` to ~> 6.1 to allow rails update on blinkbid-app

### Setup

Build the gem following [README steps](https://github.com/blinkbid/chargify_wrapper)
Open an `irb`  and require the gem
```ruby
require 'chargify_wrapper'
```

### Q & A

Setup `api_key` and `subdomain` on the irb console
Do some actions using the gem, like get subscription, mark it as canceled, etc

There should be no errors or warnings