### PR TITLE
feat(release): release version 0.5.5

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    chargify_wrapper (0.5.4)
+    chargify_wrapper (0.5.5)
       activemodel (~> 7.0.0)
       activeresource (~> 6.2)
       activesupport (~> 7.0.0)
@@ -63,7 +63,7 @@ GEM
       racc
     public_suffix (6.0.2)
     racc (1.7.1)
-    rack (3.1.21)
+    rack (3.2.6)
     rainbow (3.1.1)
     rake (13.0.6)
     regexp_parser (2.8.1)

--- a/lib/chargify_wrapper/version.rb
+++ b/lib/chargify_wrapper/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ChargifyWrapper
-  VERSION = "0.5.4"
+  VERSION = "0.5.5"
 end

--- a/spec/chargify_wrapper_spec.rb
+++ b/spec/chargify_wrapper_spec.rb
@@ -4,6 +4,6 @@ require "spec_helper"
 
 RSpec.describe ChargifyWrapper do
   it "has a version number" do
-    expect(ChargifyWrapper::VERSION).to eql("0.5.4")
+    expect(ChargifyWrapper::VERSION).to eql("0.5.5")
   end
 end


### PR DESCRIPTION
### FEATURE

Update the gem version to 0.5.5, which contains the following:
- #32 
- #33 
- #34 
- #35 

⚠️ **Breaking Changes** ⚠️

This release drops support for rails <= 6.x