### PR TITLE
feat(apply-coupons): add methods to handle coupons

### DIFF
--- a/lib/chargify_wrapper/resources/subscription.rb
+++ b/lib/chargify_wrapper/resources/subscription.rb
@@ -26,5 +26,9 @@ module ChargifyWrapper
     def apply_coupons(codes:)
       post(:add_coupon, nil, { codes: codes }.to_json)
     end
+
+    def remove_coupon(coupon_code:)
+      delete(:remove_coupon, coupon_code: coupon_code)
+    end
   end
 end

--- a/lib/chargify_wrapper/resources/subscription.rb
+++ b/lib/chargify_wrapper/resources/subscription.rb
@@ -24,7 +24,7 @@ module ChargifyWrapper
     end
 
     def apply_coupons(codes:)
-      post(:add_coupon, nil, { codes: codes }.to_json)
+      post(:add_coupon, nil, {codes: codes}.to_json)
     end
 
     def remove_coupon(coupon_code:)

--- a/lib/chargify_wrapper/resources/subscription.rb
+++ b/lib/chargify_wrapper/resources/subscription.rb
@@ -22,5 +22,9 @@ module ChargifyWrapper
         attrs.to_json(root: :subscription)
       )
     end
+
+    def apply_coupons(codes:)
+      post(:add_coupon, nil, { codes: codes }.to_json)
+    end
   end
 end

--- a/lib/chargify_wrapper/resources/subscription.rb
+++ b/lib/chargify_wrapper/resources/subscription.rb
@@ -27,8 +27,8 @@ module ChargifyWrapper
       post(:add_coupon, nil, {codes: codes}.to_json)
     end
 
-    def remove_coupon(coupon_code:)
-      delete(:remove_coupon, coupon_code: coupon_code)
+    def remove_coupon(code:)
+      delete(:remove_coupon, coupon_code: code)
     end
   end
 end

--- a/spec/fixtures/cassettes/chargify_wrapper/subscription_apply_coupons/when_codes_are_empty_raises_active_resource/resource_invalid.yml
+++ b/spec/fixtures/cassettes/chargify_wrapper/subscription_apply_coupons/when_codes_are_empty_raises_active_resource/resource_invalid.yml
@@ -1,0 +1,126 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://<CHARGIFY_SUBDOMAIN>.chargify.com/subscriptions/90823390.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - "<CHARGIFY_API_KEY>"
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 07 May 2026 16:19:34 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cache-Control:
+      - private, no-store
+      Etag:
+      - W/"7167cc9a4105544c02db70a1a3726582"
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - nginx + Phusion Passenger(R)
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - Phusion Passenger(R) Enterprise
+      X-Request-Id:
+      - 8a59287c-101d-4802-9112-b493d55914d5
+      X-Runtime:
+      - '0.092196'
+      X-Xss-Protection:
+      - 1; mode=block
+    body:
+      encoding: UTF-8
+      string: '{"subscription":{"id":90823390,"state":"trial_ended","trial_started_at":"2026-02-25T19:35:21-08:00","trial_ended_at":"2026-03-11T20:35:21-07:00","activated_at":null,"created_at":"2026-02-25T19:35:21-08:00","updated_at":"2026-05-07T09:11:21-07:00","expires_at":null,"balance_in_cents":0,"current_period_ends_at":null,"next_assessment_at":null,"canceled_at":null,"cancellation_message":"Trial
+        ended on 11 Mar 2026 8:35 PM PDT with no card on file","next_product_id":null,"next_product_handle":null,"cancel_at_end_of_period":false,"payment_collection_method":"automatic","snap_day":null,"cancellation_method":null,"current_period_started_at":null,"previous_state":"trialing","signup_payment_id":1526171986,"signup_revenue":"0.00","delayed_cancel_at":null,"coupon_code":"10DAMOUNTCODEYEAR","total_revenue_in_cents":0,"product_price_in_cents":2800,"product_version_number":1,"payment_type":null,"referral_code":null,"coupon_use_count":0,"coupon_uses_allowed":1,"reason_code":null,"automatically_resume_at":null,"coupon_codes":["10DAMOUNTCODEYEAR","25RDGABSKXBZL2","45RDLWDEMNAS"],"offer_id":null,"payer_id":null,"receives_invoice_emails":null,"product_price_point_id":3218452,"next_product_price_point_id":null,"net_terms":null,"stored_credential_transaction_id":null,"reference":null,"currency":"USD","on_hold_at":null,"scheduled_cancellation_at":null,"product_price_point_type":"default","dunning_communication_delay_enabled":false,"dunning_communication_delay_time_zone":null,"product":{"id":6723193,"name":"Solo-Monthly-T","handle":"solo-monthly-trial","description":"Users:
+        1\r\nPersonalities: 10","accounting_code":"13","request_credit_card":true,"expiration_interval":null,"expiration_interval_unit":"never","created_at":"2024-08-13T09:37:37-07:00","updated_at":"2024-08-13T09:37:37-07:00","price_in_cents":2800,"interval":1,"interval_unit":"month","initial_charge_in_cents":null,"trial_price_in_cents":0,"trial_interval":14,"trial_interval_unit":"day","trial_type":"no_obligation","archived_at":null,"require_credit_card":false,"return_params":"","taxable":false,"update_return_url":"","tax_code":"","initial_charge_after_trial":false,"version_number":1,"update_return_params":"","default_product_price_point_id":3218452,"request_billing_address":false,"require_billing_address":false,"require_shipping_address":false,"use_site_exchange_rate":true,"item_category":null,"product_price_point_id":3218452,"product_price_point_name":"New
+        Price May 2021","product_price_point_handle":"uuid:2feeb150-8c25-0139-e08c-06de0fa030d9","product_family":{"id":2682583,"name":"Blinkbid
+        - USA","description":"Blinkbid software sold in the United States, in USD
+        currency.","handle":"blinkbid-usa","accounting_code":null,"created_at":"2024-08-13T09:37:37-07:00","updated_at":"2024-08-13T09:37:37-07:00","archived_at":null},"public_signup_pages":[]},"current_billing_amount_in_cents":1155,"customer":{"id":94888728,"first_name":"Testing","last_name":"Spec","organization":null,"email":"edited_solo_monthly@test.com","created_at":"2026-02-25T19:35:21-08:00","updated_at":"2026-02-25T19:35:21-08:00","reference":null,"address":null,"address_2":null,"address_3":null,"city":null,"state":null,"state_name":null,"zip":null,"country":null,"country_name":null,"phone":null,"portal_invite_last_sent_at":null,"portal_invite_last_accepted_at":null,"verified":false,"portal_customer_created_at":null,"vat_number":null,"vat_country":null,"vat_status":"not_verified","vat_validated_at":null,"cc_emails":null,"tax_exempt":false,"tax_exempt_reason":null,"parent_id":null,"salesforce_id":null,"business_type":null,"maxioid":null}}}'
+  recorded_at: Thu, 07 May 2026 16:19:34 GMT
+- request:
+    method: post
+    uri: https://<CHARGIFY_SUBDOMAIN>.chargify.com/subscriptions/90823390/add_coupon.json
+    body:
+      encoding: UTF-8
+      string: '{"codes":[]}'
+    headers:
+      Authorization:
+      - "<CHARGIFY_API_KEY>"
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 422
+      message: Unprocessable Entity
+    headers:
+      Date:
+      - Thu, 07 May 2026 16:19:35 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cache-Control:
+      - private, no-store
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - nginx + Phusion Passenger(R)
+      Status:
+      - 422 Unprocessable Entity
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - Phusion Passenger(R) Enterprise
+      X-Request-Id:
+      - 2fb96ea0-a97a-4395-b979-47e8ea037486
+      X-Runtime:
+      - '0.015057'
+      X-Xss-Protection:
+      - 1; mode=block
+    body:
+      encoding: UTF-8
+      string: '{"subscription":["A valid coupon code is required."]}'
+  recorded_at: Thu, 07 May 2026 16:19:35 GMT
+recorded_with: VCR 6.2.0

--- a/spec/fixtures/cassettes/chargify_wrapper/subscription_apply_coupons/when_codes_are_invalid_raises_active_resource/resource_invalid.yml
+++ b/spec/fixtures/cassettes/chargify_wrapper/subscription_apply_coupons/when_codes_are_invalid_raises_active_resource/resource_invalid.yml
@@ -1,0 +1,127 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://<CHARGIFY_SUBDOMAIN>.chargify.com/subscriptions/90823390.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - "<CHARGIFY_API_KEY>"
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 07 May 2026 16:18:44 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cache-Control:
+      - private, no-store
+      Etag:
+      - W/"7167cc9a4105544c02db70a1a3726582"
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - nginx + Phusion Passenger(R)
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - Phusion Passenger(R) Enterprise
+      X-Request-Id:
+      - 78e3f57a-9482-43a2-a4f6-04edfba7abf9
+      X-Runtime:
+      - '0.124973'
+      X-Xss-Protection:
+      - 1; mode=block
+    body:
+      encoding: UTF-8
+      string: '{"subscription":{"id":90823390,"state":"trial_ended","trial_started_at":"2026-02-25T19:35:21-08:00","trial_ended_at":"2026-03-11T20:35:21-07:00","activated_at":null,"created_at":"2026-02-25T19:35:21-08:00","updated_at":"2026-05-07T09:11:21-07:00","expires_at":null,"balance_in_cents":0,"current_period_ends_at":null,"next_assessment_at":null,"canceled_at":null,"cancellation_message":"Trial
+        ended on 11 Mar 2026 8:35 PM PDT with no card on file","next_product_id":null,"next_product_handle":null,"cancel_at_end_of_period":false,"payment_collection_method":"automatic","snap_day":null,"cancellation_method":null,"current_period_started_at":null,"previous_state":"trialing","signup_payment_id":1526171986,"signup_revenue":"0.00","delayed_cancel_at":null,"coupon_code":"10DAMOUNTCODEYEAR","total_revenue_in_cents":0,"product_price_in_cents":2800,"product_version_number":1,"payment_type":null,"referral_code":null,"coupon_use_count":0,"coupon_uses_allowed":1,"reason_code":null,"automatically_resume_at":null,"coupon_codes":["10DAMOUNTCODEYEAR","25RDGABSKXBZL2","45RDLWDEMNAS"],"offer_id":null,"payer_id":null,"receives_invoice_emails":null,"product_price_point_id":3218452,"next_product_price_point_id":null,"net_terms":null,"stored_credential_transaction_id":null,"reference":null,"currency":"USD","on_hold_at":null,"scheduled_cancellation_at":null,"product_price_point_type":"default","dunning_communication_delay_enabled":false,"dunning_communication_delay_time_zone":null,"product":{"id":6723193,"name":"Solo-Monthly-T","handle":"solo-monthly-trial","description":"Users:
+        1\r\nPersonalities: 10","accounting_code":"13","request_credit_card":true,"expiration_interval":null,"expiration_interval_unit":"never","created_at":"2024-08-13T09:37:37-07:00","updated_at":"2024-08-13T09:37:37-07:00","price_in_cents":2800,"interval":1,"interval_unit":"month","initial_charge_in_cents":null,"trial_price_in_cents":0,"trial_interval":14,"trial_interval_unit":"day","trial_type":"no_obligation","archived_at":null,"require_credit_card":false,"return_params":"","taxable":false,"update_return_url":"","tax_code":"","initial_charge_after_trial":false,"version_number":1,"update_return_params":"","default_product_price_point_id":3218452,"request_billing_address":false,"require_billing_address":false,"require_shipping_address":false,"use_site_exchange_rate":true,"item_category":null,"product_price_point_id":3218452,"product_price_point_name":"New
+        Price May 2021","product_price_point_handle":"uuid:2feeb150-8c25-0139-e08c-06de0fa030d9","product_family":{"id":2682583,"name":"Blinkbid
+        - USA","description":"Blinkbid software sold in the United States, in USD
+        currency.","handle":"blinkbid-usa","accounting_code":null,"created_at":"2024-08-13T09:37:37-07:00","updated_at":"2024-08-13T09:37:37-07:00","archived_at":null},"public_signup_pages":[]},"current_billing_amount_in_cents":1155,"customer":{"id":94888728,"first_name":"Testing","last_name":"Spec","organization":null,"email":"edited_solo_monthly@test.com","created_at":"2026-02-25T19:35:21-08:00","updated_at":"2026-02-25T19:35:21-08:00","reference":null,"address":null,"address_2":null,"address_3":null,"city":null,"state":null,"state_name":null,"zip":null,"country":null,"country_name":null,"phone":null,"portal_invite_last_sent_at":null,"portal_invite_last_accepted_at":null,"verified":false,"portal_customer_created_at":null,"vat_number":null,"vat_country":null,"vat_status":"not_verified","vat_validated_at":null,"cc_emails":null,"tax_exempt":false,"tax_exempt_reason":null,"parent_id":null,"salesforce_id":null,"business_type":null,"maxioid":null}}}'
+  recorded_at: Thu, 07 May 2026 16:18:45 GMT
+- request:
+    method: post
+    uri: https://<CHARGIFY_SUBDOMAIN>.chargify.com/subscriptions/90823390/add_coupon.json
+    body:
+      encoding: UTF-8
+      string: '{"codes":["INVALID"]}'
+    headers:
+      Authorization:
+      - "<CHARGIFY_API_KEY>"
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 422
+      message: Unprocessable Entity
+    headers:
+      Date:
+      - Thu, 07 May 2026 16:18:45 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cache-Control:
+      - private, no-store
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - nginx + Phusion Passenger(R)
+      Status:
+      - 422 Unprocessable Entity
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - Phusion Passenger(R) Enterprise
+      X-Request-Id:
+      - 07f7f184-1796-447b-a566-de37cc478143
+      X-Runtime:
+      - '0.035211'
+      X-Xss-Protection:
+      - 1; mode=block
+    body:
+      encoding: UTF-8
+      string: '{"coupon_codes":["Coupon Codes: ''INVALID'' - Coupon code could not
+        be found."],"subscription":["Coupon is invalid."]}'
+  recorded_at: Thu, 07 May 2026 16:18:45 GMT
+recorded_with: VCR 6.2.0

--- a/spec/fixtures/cassettes/chargify_wrapper/subscription_apply_coupons/when_codes_are_valid_returns_net/httpok.yml
+++ b/spec/fixtures/cassettes/chargify_wrapper/subscription_apply_coupons/when_codes_are_valid_returns_net/httpok.yml
@@ -1,0 +1,135 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://<CHARGIFY_SUBDOMAIN>.chargify.com/subscriptions/90823390.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - "<CHARGIFY_API_KEY>"
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 07 May 2026 16:14:26 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cache-Control:
+      - private, no-store
+      Etag:
+      - W/"7167cc9a4105544c02db70a1a3726582"
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - nginx + Phusion Passenger(R)
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - Phusion Passenger(R) Enterprise
+      X-Request-Id:
+      - ee0fa623-4091-48e5-a7c0-fb77030cd446
+      X-Runtime:
+      - '0.097816'
+      X-Xss-Protection:
+      - 1; mode=block
+    body:
+      encoding: UTF-8
+      string: '{"subscription":{"id":90823390,"state":"trial_ended","trial_started_at":"2026-02-25T19:35:21-08:00","trial_ended_at":"2026-03-11T20:35:21-07:00","activated_at":null,"created_at":"2026-02-25T19:35:21-08:00","updated_at":"2026-05-07T09:11:21-07:00","expires_at":null,"balance_in_cents":0,"current_period_ends_at":null,"next_assessment_at":null,"canceled_at":null,"cancellation_message":"Trial
+        ended on 11 Mar 2026 8:35 PM PDT with no card on file","next_product_id":null,"next_product_handle":null,"cancel_at_end_of_period":false,"payment_collection_method":"automatic","snap_day":null,"cancellation_method":null,"current_period_started_at":null,"previous_state":"trialing","signup_payment_id":1526171986,"signup_revenue":"0.00","delayed_cancel_at":null,"coupon_code":"10DAMOUNTCODEYEAR","total_revenue_in_cents":0,"product_price_in_cents":2800,"product_version_number":1,"payment_type":null,"referral_code":null,"coupon_use_count":0,"coupon_uses_allowed":1,"reason_code":null,"automatically_resume_at":null,"coupon_codes":[],"offer_id":null,"payer_id":null,"receives_invoice_emails":null,"product_price_point_id":3218452,"next_product_price_point_id":null,"net_terms":null,"stored_credential_transaction_id":null,"reference":null,"currency":"USD","on_hold_at":null,"scheduled_cancellation_at":null,"product_price_point_type":"default","dunning_communication_delay_enabled":false,"dunning_communication_delay_time_zone":null,"product":{"id":6723193,"name":"Solo-Monthly-T","handle":"solo-monthly-trial","description":"Users:
+        1\r\nPersonalities: 10","accounting_code":"13","request_credit_card":true,"expiration_interval":null,"expiration_interval_unit":"never","created_at":"2024-08-13T09:37:37-07:00","updated_at":"2024-08-13T09:37:37-07:00","price_in_cents":2800,"interval":1,"interval_unit":"month","initial_charge_in_cents":null,"trial_price_in_cents":0,"trial_interval":14,"trial_interval_unit":"day","trial_type":"no_obligation","archived_at":null,"require_credit_card":false,"return_params":"","taxable":false,"update_return_url":"","tax_code":"","initial_charge_after_trial":false,"version_number":1,"update_return_params":"","default_product_price_point_id":3218452,"request_billing_address":false,"require_billing_address":false,"require_shipping_address":false,"use_site_exchange_rate":true,"item_category":null,"product_price_point_id":3218452,"product_price_point_name":"New
+        Price May 2021","product_price_point_handle":"uuid:2feeb150-8c25-0139-e08c-06de0fa030d9","product_family":{"id":2682583,"name":"Blinkbid
+        - USA","description":"Blinkbid software sold in the United States, in USD
+        currency.","handle":"blinkbid-usa","accounting_code":null,"created_at":"2024-08-13T09:37:37-07:00","updated_at":"2024-08-13T09:37:37-07:00","archived_at":null},"public_signup_pages":[]},"current_billing_amount_in_cents":1155,"customer":{"id":94888728,"first_name":"Testing","last_name":"Spec","organization":null,"email":"edited_solo_monthly@test.com","created_at":"2026-02-25T19:35:21-08:00","updated_at":"2026-02-25T19:35:21-08:00","reference":null,"address":null,"address_2":null,"address_3":null,"city":null,"state":null,"state_name":null,"zip":null,"country":null,"country_name":null,"phone":null,"portal_invite_last_sent_at":null,"portal_invite_last_accepted_at":null,"verified":false,"portal_customer_created_at":null,"vat_number":null,"vat_country":null,"vat_status":"not_verified","vat_validated_at":null,"cc_emails":null,"tax_exempt":false,"tax_exempt_reason":null,"parent_id":null,"salesforce_id":null,"business_type":null,"maxioid":null}}}'
+  recorded_at: Thu, 07 May 2026 16:14:26 GMT
+- request:
+    method: post
+    uri: https://<CHARGIFY_SUBDOMAIN>.chargify.com/subscriptions/90823390/add_coupon.json
+    body:
+      encoding: UTF-8
+      string: '{"codes":["10DAMOUNTCODEYEAR"]}'
+    headers:
+      Authorization:
+      - "<CHARGIFY_API_KEY>"
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 07 May 2026 16:14:26 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cache-Control:
+      - private, no-store
+      Etag:
+      - W/"9c3838c426788bce29926af2264f1245"
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - nginx + Phusion Passenger(R)
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - Phusion Passenger(R) Enterprise
+      X-Request-Id:
+      - 0d57b95e-e6e9-4856-a110-d19abed335ac
+      X-Runtime:
+      - '0.060008'
+      X-Xss-Protection:
+      - 1; mode=block
+    body:
+      encoding: UTF-8
+      string: '{"subscription":{"id":90823390,"state":"trial_ended","trial_started_at":"2026-02-25T19:35:21-08:00","trial_ended_at":"2026-03-11T20:35:21-07:00","activated_at":null,"created_at":"2026-02-25T19:35:21-08:00","updated_at":"2026-05-07T09:11:21-07:00","expires_at":null,"balance_in_cents":0,"current_period_ends_at":null,"next_assessment_at":null,"canceled_at":null,"cancellation_message":"Trial
+        ended on 11 Mar 2026 8:35 PM PDT with no card on file","next_product_id":null,"cancel_at_end_of_period":false,"payment_collection_method":"automatic","snap_day":null,"cancellation_method":null,"product_price_point_id":3218452,"next_product_price_point_id":null,"receives_invoice_emails":null,"net_terms":null,"currency":"USD","reference":null,"scheduled_cancellation_at":null,"current_period_started_at":null,"previous_state":"trialing","signup_payment_id":1526171986,"signup_revenue":"0.00","delayed_cancel_at":null,"coupon_code":"10DAMOUNTCODEYEAR","total_revenue_in_cents":0,"product_price_in_cents":2800,"product_version_number":1,"payment_type":null,"referral_code":null,"coupon_use_count":0,"coupon_uses_allowed":1,"reason_code":null,"automatically_resume_at":null,"coupon_codes":["10DAMOUNTCODEYEAR"],"offer_id":null,"payer_id":null,"stored_credential_transaction_id":null,"next_product_handle":null,"on_hold_at":null,"customer":{"id":94888728,"first_name":"Testing","last_name":"Spec","organization":null,"email":"edited_solo_monthly@test.com","created_at":"2026-02-25T19:35:21-08:00","updated_at":"2026-02-25T19:35:21-08:00","reference":null,"address":null,"address_2":null,"address_3":null,"city":null,"state":null,"zip":null,"country":null,"phone":null,"portal_invite_last_sent_at":null,"portal_invite_last_accepted_at":null,"verified":false,"portal_customer_created_at":null,"vat_number":null,"cc_emails":null,"tax_exempt":false,"tax_exempt_reason":null,"parent_id":null,"locale":null,"salesforce_id":null,"default_auto_renewal_profile_id":null,"business_type":null,"vat_country":null,"vat_status":"not_verified","vat_validated_at":null,"maxioid":null},"product":{"id":6723193,"name":"Solo-Monthly-T","handle":"solo-monthly-trial","description":"Users:
+        1\r\nPersonalities: 10","accounting_code":"13","request_credit_card":true,"expiration_interval":null,"expiration_interval_unit":"never","created_at":"2024-08-13T09:37:37-07:00","updated_at":"2024-08-13T09:37:37-07:00","price_in_cents":2800,"interval":1,"interval_unit":"month","initial_charge_in_cents":null,"trial_price_in_cents":0,"trial_interval":14,"trial_interval_unit":"day","archived_at":null,"require_credit_card":false,"return_params":"","require_shipping_address":false,"request_billing_address":false,"require_billing_address":false,"taxable":false,"update_return_url":"","tax_code":"","initial_charge_after_trial":false,"default_product_price_point_id":3218452,"item_category":null,"trial_type":"no_obligation","version_number":1,"update_return_params":"","product_price_point_id":3218452,"product_price_point_name":"New
+        Price May 2021","product_price_point_handle":"uuid:2feeb150-8c25-0139-e08c-06de0fa030d9","use_site_exchange_rate":true,"product_family":{"id":2682583,"name":"Blinkbid
+        - USA","description":"Blinkbid software sold in the United States, in USD
+        currency.","handle":"blinkbid-usa","accounting_code":null,"archived_at":null,"created_at":"2024-08-13T09:37:37-07:00","updated_at":"2024-08-13T09:37:37-07:00"},"public_signup_pages":[]}}}'
+  recorded_at: Thu, 07 May 2026 16:14:26 GMT
+recorded_with: VCR 6.2.0

--- a/spec/fixtures/cassettes/chargify_wrapper/subscription_apply_coupons/when_codes_are_valid_sends_the_request_correctly.yml
+++ b/spec/fixtures/cassettes/chargify_wrapper/subscription_apply_coupons/when_codes_are_valid_sends_the_request_correctly.yml
@@ -1,0 +1,135 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://<CHARGIFY_SUBDOMAIN>.chargify.com/subscriptions/90823390.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - "<CHARGIFY_API_KEY>"
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 07 May 2026 16:14:52 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cache-Control:
+      - private, no-store
+      Etag:
+      - W/"7167cc9a4105544c02db70a1a3726582"
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - nginx + Phusion Passenger(R)
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - Phusion Passenger(R) Enterprise
+      X-Request-Id:
+      - 0b46160d-1303-433e-98c3-05bc23fe97f7
+      X-Runtime:
+      - '0.119827'
+      X-Xss-Protection:
+      - 1; mode=block
+    body:
+      encoding: UTF-8
+      string: '{"subscription":{"id":90823390,"state":"trial_ended","trial_started_at":"2026-02-25T19:35:21-08:00","trial_ended_at":"2026-03-11T20:35:21-07:00","activated_at":null,"created_at":"2026-02-25T19:35:21-08:00","updated_at":"2026-05-07T09:11:21-07:00","expires_at":null,"balance_in_cents":0,"current_period_ends_at":null,"next_assessment_at":null,"canceled_at":null,"cancellation_message":"Trial
+        ended on 11 Mar 2026 8:35 PM PDT with no card on file","next_product_id":null,"next_product_handle":null,"cancel_at_end_of_period":false,"payment_collection_method":"automatic","snap_day":null,"cancellation_method":null,"current_period_started_at":null,"previous_state":"trialing","signup_payment_id":1526171986,"signup_revenue":"0.00","delayed_cancel_at":null,"coupon_code":"10DAMOUNTCODEYEAR","total_revenue_in_cents":0,"product_price_in_cents":2800,"product_version_number":1,"payment_type":null,"referral_code":null,"coupon_use_count":0,"coupon_uses_allowed":1,"reason_code":null,"automatically_resume_at":null,"coupon_codes":["10DAMOUNTCODEYEAR","25RDGABSKXBZL2","45RDLWDEMNAS"],"offer_id":null,"payer_id":null,"receives_invoice_emails":null,"product_price_point_id":3218452,"next_product_price_point_id":null,"net_terms":null,"stored_credential_transaction_id":null,"reference":null,"currency":"USD","on_hold_at":null,"scheduled_cancellation_at":null,"product_price_point_type":"default","dunning_communication_delay_enabled":false,"dunning_communication_delay_time_zone":null,"product":{"id":6723193,"name":"Solo-Monthly-T","handle":"solo-monthly-trial","description":"Users:
+        1\r\nPersonalities: 10","accounting_code":"13","request_credit_card":true,"expiration_interval":null,"expiration_interval_unit":"never","created_at":"2024-08-13T09:37:37-07:00","updated_at":"2024-08-13T09:37:37-07:00","price_in_cents":2800,"interval":1,"interval_unit":"month","initial_charge_in_cents":null,"trial_price_in_cents":0,"trial_interval":14,"trial_interval_unit":"day","trial_type":"no_obligation","archived_at":null,"require_credit_card":false,"return_params":"","taxable":false,"update_return_url":"","tax_code":"","initial_charge_after_trial":false,"version_number":1,"update_return_params":"","default_product_price_point_id":3218452,"request_billing_address":false,"require_billing_address":false,"require_shipping_address":false,"use_site_exchange_rate":true,"item_category":null,"product_price_point_id":3218452,"product_price_point_name":"New
+        Price May 2021","product_price_point_handle":"uuid:2feeb150-8c25-0139-e08c-06de0fa030d9","product_family":{"id":2682583,"name":"Blinkbid
+        - USA","description":"Blinkbid software sold in the United States, in USD
+        currency.","handle":"blinkbid-usa","accounting_code":null,"created_at":"2024-08-13T09:37:37-07:00","updated_at":"2024-08-13T09:37:37-07:00","archived_at":null},"public_signup_pages":[]},"current_billing_amount_in_cents":1155,"customer":{"id":94888728,"first_name":"Testing","last_name":"Spec","organization":null,"email":"edited_solo_monthly@test.com","created_at":"2026-02-25T19:35:21-08:00","updated_at":"2026-02-25T19:35:21-08:00","reference":null,"address":null,"address_2":null,"address_3":null,"city":null,"state":null,"state_name":null,"zip":null,"country":null,"country_name":null,"phone":null,"portal_invite_last_sent_at":null,"portal_invite_last_accepted_at":null,"verified":false,"portal_customer_created_at":null,"vat_number":null,"vat_country":null,"vat_status":"not_verified","vat_validated_at":null,"cc_emails":null,"tax_exempt":false,"tax_exempt_reason":null,"parent_id":null,"salesforce_id":null,"business_type":null,"maxioid":null}}}'
+  recorded_at: Thu, 07 May 2026 16:14:52 GMT
+- request:
+    method: post
+    uri: https://<CHARGIFY_SUBDOMAIN>.chargify.com/subscriptions/90823390/add_coupon.json
+    body:
+      encoding: UTF-8
+      string: '{"codes":["25RDGABSKXBZL2","45RDLWDEMNAS"]}'
+    headers:
+      Authorization:
+      - "<CHARGIFY_API_KEY>"
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 07 May 2026 16:14:53 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cache-Control:
+      - private, no-store
+      Etag:
+      - W/"9c3838c426788bce29926af2264f1245"
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - nginx + Phusion Passenger(R)
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - Phusion Passenger(R) Enterprise
+      X-Request-Id:
+      - 5bc264f5-2ab4-4d54-b3df-58e00af93f7b
+      X-Runtime:
+      - '0.066351'
+      X-Xss-Protection:
+      - 1; mode=block
+    body:
+      encoding: UTF-8
+      string: '{"subscription":{"id":90823390,"state":"trial_ended","trial_started_at":"2026-02-25T19:35:21-08:00","trial_ended_at":"2026-03-11T20:35:21-07:00","activated_at":null,"created_at":"2026-02-25T19:35:21-08:00","updated_at":"2026-05-07T09:11:21-07:00","expires_at":null,"balance_in_cents":0,"current_period_ends_at":null,"next_assessment_at":null,"canceled_at":null,"cancellation_message":"Trial
+        ended on 11 Mar 2026 8:35 PM PDT with no card on file","next_product_id":null,"cancel_at_end_of_period":false,"payment_collection_method":"automatic","snap_day":null,"cancellation_method":null,"product_price_point_id":3218452,"next_product_price_point_id":null,"receives_invoice_emails":null,"net_terms":null,"currency":"USD","reference":null,"scheduled_cancellation_at":null,"current_period_started_at":null,"previous_state":"trialing","signup_payment_id":1526171986,"signup_revenue":"0.00","delayed_cancel_at":null,"coupon_code":"10DAMOUNTCODEYEAR","total_revenue_in_cents":0,"product_price_in_cents":2800,"product_version_number":1,"payment_type":null,"referral_code":null,"coupon_use_count":0,"coupon_uses_allowed":1,"reason_code":null,"automatically_resume_at":null,"coupon_codes":["10DAMOUNTCODEYEAR","25RDGABSKXBZL2","45RDLWDEMNAS"],"offer_id":null,"payer_id":null,"stored_credential_transaction_id":null,"next_product_handle":null,"on_hold_at":null,"customer":{"id":94888728,"first_name":"Testing","last_name":"Spec","organization":null,"email":"edited_solo_monthly@test.com","created_at":"2026-02-25T19:35:21-08:00","updated_at":"2026-02-25T19:35:21-08:00","reference":null,"address":null,"address_2":null,"address_3":null,"city":null,"state":null,"zip":null,"country":null,"phone":null,"portal_invite_last_sent_at":null,"portal_invite_last_accepted_at":null,"verified":false,"portal_customer_created_at":null,"vat_number":null,"cc_emails":null,"tax_exempt":false,"tax_exempt_reason":null,"parent_id":null,"locale":null,"salesforce_id":null,"default_auto_renewal_profile_id":null,"business_type":null,"vat_country":null,"vat_status":"not_verified","vat_validated_at":null,"maxioid":null},"product":{"id":6723193,"name":"Solo-Monthly-T","handle":"solo-monthly-trial","description":"Users:
+        1\r\nPersonalities: 10","accounting_code":"13","request_credit_card":true,"expiration_interval":null,"expiration_interval_unit":"never","created_at":"2024-08-13T09:37:37-07:00","updated_at":"2024-08-13T09:37:37-07:00","price_in_cents":2800,"interval":1,"interval_unit":"month","initial_charge_in_cents":null,"trial_price_in_cents":0,"trial_interval":14,"trial_interval_unit":"day","archived_at":null,"require_credit_card":false,"return_params":"","require_shipping_address":false,"request_billing_address":false,"require_billing_address":false,"taxable":false,"update_return_url":"","tax_code":"","initial_charge_after_trial":false,"default_product_price_point_id":3218452,"item_category":null,"trial_type":"no_obligation","version_number":1,"update_return_params":"","product_price_point_id":3218452,"product_price_point_name":"New
+        Price May 2021","product_price_point_handle":"uuid:2feeb150-8c25-0139-e08c-06de0fa030d9","use_site_exchange_rate":true,"product_family":{"id":2682583,"name":"Blinkbid
+        - USA","description":"Blinkbid software sold in the United States, in USD
+        currency.","handle":"blinkbid-usa","accounting_code":null,"archived_at":null,"created_at":"2024-08-13T09:37:37-07:00","updated_at":"2024-08-13T09:37:37-07:00"},"public_signup_pages":[]}}}'
+  recorded_at: Thu, 07 May 2026 16:14:53 GMT
+recorded_with: VCR 6.2.0

--- a/spec/fixtures/cassettes/chargify_wrapper/subscription_remove_coupon/remove_coupon_fails.yml
+++ b/spec/fixtures/cassettes/chargify_wrapper/subscription_remove_coupon/remove_coupon_fails.yml
@@ -1,0 +1,124 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://<CHARGIFY_SUBDOMAIN>.chargify.com/subscriptions/90823390.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - "<CHARGIFY_API_KEY>"
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 08 May 2026 20:41:43 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cache-Control:
+      - private, no-store
+      Etag:
+      - W/"55f57733478a10e83ba5248f66689b50"
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - nginx + Phusion Passenger(R)
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - Phusion Passenger(R) Enterprise
+      X-Request-Id:
+      - 2894e972-606b-4c6f-8241-0718743375f1
+      X-Runtime:
+      - '0.077604'
+      X-Xss-Protection:
+      - 1; mode=block
+    body:
+      encoding: UTF-8
+      string: '{"subscription":{"id":90823390,"state":"trial_ended","trial_started_at":"2026-02-25T19:35:21-08:00","trial_ended_at":"2026-03-11T20:35:21-07:00","activated_at":null,"created_at":"2026-02-25T19:35:21-08:00","updated_at":"2026-05-08T13:41:42-07:00","expires_at":null,"balance_in_cents":0,"current_period_ends_at":null,"next_assessment_at":null,"canceled_at":null,"cancellation_message":"Trial
+        ended on 11 Mar 2026 8:35 PM PDT with no card on file","next_product_id":null,"next_product_handle":null,"cancel_at_end_of_period":false,"payment_collection_method":"automatic","snap_day":null,"cancellation_method":null,"current_period_started_at":null,"previous_state":"trialing","signup_payment_id":1526171986,"signup_revenue":"0.00","delayed_cancel_at":null,"coupon_code":"10DAMOUNTCODEYEAR","total_revenue_in_cents":0,"product_price_in_cents":2800,"product_version_number":1,"payment_type":null,"referral_code":null,"coupon_use_count":0,"coupon_uses_allowed":1,"reason_code":null,"automatically_resume_at":null,"coupon_codes":["10DAMOUNTCODEYEAR","25RDGABSKXBZL2"],"offer_id":null,"payer_id":null,"receives_invoice_emails":null,"product_price_point_id":3218452,"next_product_price_point_id":null,"net_terms":null,"stored_credential_transaction_id":null,"reference":null,"currency":"USD","on_hold_at":null,"scheduled_cancellation_at":null,"product_price_point_type":"default","dunning_communication_delay_enabled":false,"dunning_communication_delay_time_zone":null,"product":{"id":6723193,"name":"Solo-Monthly-T","handle":"solo-monthly-trial","description":"Users:
+        1\r\nPersonalities: 10","accounting_code":"13","request_credit_card":true,"expiration_interval":null,"expiration_interval_unit":"never","created_at":"2024-08-13T09:37:37-07:00","updated_at":"2024-08-13T09:37:37-07:00","price_in_cents":2800,"interval":1,"interval_unit":"month","initial_charge_in_cents":null,"trial_price_in_cents":0,"trial_interval":14,"trial_interval_unit":"day","trial_type":"no_obligation","archived_at":null,"require_credit_card":false,"return_params":"","taxable":false,"update_return_url":"","tax_code":"","initial_charge_after_trial":false,"version_number":1,"update_return_params":"","default_product_price_point_id":3218452,"request_billing_address":false,"require_billing_address":false,"require_shipping_address":false,"use_site_exchange_rate":true,"item_category":null,"product_price_point_id":3218452,"product_price_point_name":"New
+        Price May 2021","product_price_point_handle":"uuid:2feeb150-8c25-0139-e08c-06de0fa030d9","product_family":{"id":2682583,"name":"Blinkbid
+        - USA","description":"Blinkbid software sold in the United States, in USD
+        currency.","handle":"blinkbid-usa","accounting_code":null,"created_at":"2024-08-13T09:37:37-07:00","updated_at":"2024-08-13T09:37:37-07:00","archived_at":null},"public_signup_pages":[]},"current_billing_amount_in_cents":2100,"customer":{"id":94888728,"first_name":"Testing","last_name":"Spec","organization":null,"email":"edited_solo_monthly@test.com","created_at":"2026-02-25T19:35:21-08:00","updated_at":"2026-02-25T19:35:21-08:00","reference":null,"address":null,"address_2":null,"address_3":null,"city":null,"state":null,"state_name":null,"zip":null,"country":null,"country_name":null,"phone":null,"portal_invite_last_sent_at":null,"portal_invite_last_accepted_at":null,"verified":false,"portal_customer_created_at":null,"vat_number":null,"vat_country":null,"vat_status":"not_verified","vat_validated_at":null,"cc_emails":null,"tax_exempt":false,"tax_exempt_reason":null,"parent_id":null,"salesforce_id":null,"business_type":null,"maxioid":null}}}'
+  recorded_at: Fri, 08 May 2026 20:41:43 GMT
+- request:
+    method: delete
+    uri: https://<CHARGIFY_SUBDOMAIN>.chargify.com/subscriptions/90823390/remove_coupon.json?coupon_code=NOT_ON_SUB
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - "<CHARGIFY_API_KEY>"
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 422
+      message: Unprocessable Entity
+    headers:
+      Date:
+      - Fri, 08 May 2026 20:41:43 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cache-Control:
+      - private, no-store
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - nginx + Phusion Passenger(R)
+      Status:
+      - 422 Unprocessable Entity
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - Phusion Passenger(R) Enterprise
+      X-Request-Id:
+      - 3b4ef19a-492a-4385-9dc1-998f976384db
+      X-Runtime:
+      - '0.026331'
+      X-Xss-Protection:
+      - 1; mode=block
+    body:
+      encoding: UTF-8
+      string: '{"subscription":["Coupon is invalid."]}'
+  recorded_at: Fri, 08 May 2026 20:41:43 GMT
+recorded_with: VCR 6.2.0

--- a/spec/fixtures/cassettes/chargify_wrapper/subscription_remove_coupon/remove_coupon_succeeds.yml
+++ b/spec/fixtures/cassettes/chargify_wrapper/subscription_remove_coupon/remove_coupon_succeeds.yml
@@ -1,0 +1,128 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://<CHARGIFY_SUBDOMAIN>.chargify.com/subscriptions/90823390.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - "<CHARGIFY_API_KEY>"
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 08 May 2026 20:41:41 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cache-Control:
+      - private, no-store
+      Etag:
+      - W/"7167cc9a4105544c02db70a1a3726582"
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - nginx + Phusion Passenger(R)
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - Phusion Passenger(R) Enterprise
+      X-Request-Id:
+      - 4234e1dc-44ac-46fc-bb1a-46d7e81cec68
+      X-Runtime:
+      - '0.117763'
+      X-Xss-Protection:
+      - 1; mode=block
+    body:
+      encoding: UTF-8
+      string: '{"subscription":{"id":90823390,"state":"trial_ended","trial_started_at":"2026-02-25T19:35:21-08:00","trial_ended_at":"2026-03-11T20:35:21-07:00","activated_at":null,"created_at":"2026-02-25T19:35:21-08:00","updated_at":"2026-05-07T09:11:21-07:00","expires_at":null,"balance_in_cents":0,"current_period_ends_at":null,"next_assessment_at":null,"canceled_at":null,"cancellation_message":"Trial
+        ended on 11 Mar 2026 8:35 PM PDT with no card on file","next_product_id":null,"next_product_handle":null,"cancel_at_end_of_period":false,"payment_collection_method":"automatic","snap_day":null,"cancellation_method":null,"current_period_started_at":null,"previous_state":"trialing","signup_payment_id":1526171986,"signup_revenue":"0.00","delayed_cancel_at":null,"coupon_code":"10DAMOUNTCODEYEAR","total_revenue_in_cents":0,"product_price_in_cents":2800,"product_version_number":1,"payment_type":null,"referral_code":null,"coupon_use_count":0,"coupon_uses_allowed":1,"reason_code":null,"automatically_resume_at":null,"coupon_codes":["10DAMOUNTCODEYEAR","25RDGABSKXBZL2","45RDLWDEMNAS"],"offer_id":null,"payer_id":null,"receives_invoice_emails":null,"product_price_point_id":3218452,"next_product_price_point_id":null,"net_terms":null,"stored_credential_transaction_id":null,"reference":null,"currency":"USD","on_hold_at":null,"scheduled_cancellation_at":null,"product_price_point_type":"default","dunning_communication_delay_enabled":false,"dunning_communication_delay_time_zone":null,"product":{"id":6723193,"name":"Solo-Monthly-T","handle":"solo-monthly-trial","description":"Users:
+        1\r\nPersonalities: 10","accounting_code":"13","request_credit_card":true,"expiration_interval":null,"expiration_interval_unit":"never","created_at":"2024-08-13T09:37:37-07:00","updated_at":"2024-08-13T09:37:37-07:00","price_in_cents":2800,"interval":1,"interval_unit":"month","initial_charge_in_cents":null,"trial_price_in_cents":0,"trial_interval":14,"trial_interval_unit":"day","trial_type":"no_obligation","archived_at":null,"require_credit_card":false,"return_params":"","taxable":false,"update_return_url":"","tax_code":"","initial_charge_after_trial":false,"version_number":1,"update_return_params":"","default_product_price_point_id":3218452,"request_billing_address":false,"require_billing_address":false,"require_shipping_address":false,"use_site_exchange_rate":true,"item_category":null,"product_price_point_id":3218452,"product_price_point_name":"New
+        Price May 2021","product_price_point_handle":"uuid:2feeb150-8c25-0139-e08c-06de0fa030d9","product_family":{"id":2682583,"name":"Blinkbid
+        - USA","description":"Blinkbid software sold in the United States, in USD
+        currency.","handle":"blinkbid-usa","accounting_code":null,"created_at":"2024-08-13T09:37:37-07:00","updated_at":"2024-08-13T09:37:37-07:00","archived_at":null},"public_signup_pages":[]},"current_billing_amount_in_cents":1155,"customer":{"id":94888728,"first_name":"Testing","last_name":"Spec","organization":null,"email":"edited_solo_monthly@test.com","created_at":"2026-02-25T19:35:21-08:00","updated_at":"2026-02-25T19:35:21-08:00","reference":null,"address":null,"address_2":null,"address_3":null,"city":null,"state":null,"state_name":null,"zip":null,"country":null,"country_name":null,"phone":null,"portal_invite_last_sent_at":null,"portal_invite_last_accepted_at":null,"verified":false,"portal_customer_created_at":null,"vat_number":null,"vat_country":null,"vat_status":"not_verified","vat_validated_at":null,"cc_emails":null,"tax_exempt":false,"tax_exempt_reason":null,"parent_id":null,"salesforce_id":null,"business_type":null,"maxioid":null}}}'
+  recorded_at: Fri, 08 May 2026 20:41:41 GMT
+- request:
+    method: delete
+    uri: https://<CHARGIFY_SUBDOMAIN>.chargify.com/subscriptions/90823390/remove_coupon.json?coupon_code=45RDLWDEMNAS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - "<CHARGIFY_API_KEY>"
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 08 May 2026 20:41:42 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cache-Control:
+      - private, no-store
+      Etag:
+      - W/"f864722e0804e343288700b3fa6d8d85"
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - nginx + Phusion Passenger(R)
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Powered-By:
+      - Phusion Passenger(R) Enterprise
+      X-Request-Id:
+      - 82f8121e-c49a-4429-a432-6d6b9a9dd789
+      X-Runtime:
+      - '0.031993'
+      X-Xss-Protection:
+      - 1; mode=block
+    body:
+      encoding: UTF-8
+      string: Coupon successfully removed.
+  recorded_at: Fri, 08 May 2026 20:41:42 GMT
+recorded_with: VCR 6.2.0

--- a/spec/resources/subscription_spec.rb
+++ b/spec/resources/subscription_spec.rb
@@ -188,4 +188,37 @@ RSpec.describe ChargifyWrapper::Subscription do
       end
     end
   end
+
+  describe "#remove_coupon", :vcr do
+    let(:subscription) { described_class.find(90823390) }
+    let(:url_matcher) do
+      Regexp.new(".chargify.com/subscriptions/#{subscription.id}/remove_coupon\\.json")
+    end
+
+    context "when coupon code is on the subscription" do
+      it "returns Net::HTTPOK",
+        cassette: "chargify_wrapper/subscription_remove_coupon/remove_coupon_succeeds" do
+        response = subscription.remove_coupon(coupon_code: "45RDLWDEMNAS")
+
+        expect(response).to be_a(Net::HTTPOK)
+        expect(response.body.strip).to eq("Coupon successfully removed.")
+      end
+
+      it "sends DELETE with coupon_code query param",
+        cassette: "chargify_wrapper/subscription_remove_coupon/remove_coupon_succeeds" do
+        subscription.remove_coupon(coupon_code: "45RDLWDEMNAS")
+
+        expect(WebMock).to have_requested(:delete, url_matcher)
+          .with(query: {"coupon_code" => "45RDLWDEMNAS"}).once
+      end
+    end
+
+    context "when coupon code is not on the subscription" do
+      it "raises ActiveResource::ResourceInvalid",
+        cassette: "chargify_wrapper/subscription_remove_coupon/remove_coupon_fails" do
+        expect { subscription.remove_coupon(coupon_code: "NOT_ON_SUB") }
+          .to raise_error(ActiveResource::ResourceInvalid)
+      end
+    end
+  end
 end

--- a/spec/resources/subscription_spec.rb
+++ b/spec/resources/subscription_spec.rb
@@ -200,7 +200,7 @@ RSpec.describe ChargifyWrapper::Subscription do
     context "when coupon code is on the subscription" do
       it "returns Net::HTTPOK",
         cassette: "chargify_wrapper/subscription_remove_coupon/remove_coupon_succeeds" do
-        response = subscription.remove_coupon(coupon_code: "45RDLWDEMNAS")
+        response = subscription.remove_coupon(code: "45RDLWDEMNAS")
 
         expect(response).to be_a(Net::HTTPOK).and(
           satisfy { |r| r.body.strip == "Coupon successfully removed." }
@@ -209,7 +209,7 @@ RSpec.describe ChargifyWrapper::Subscription do
 
       it "sends DELETE with coupon_code query param",
         cassette: "chargify_wrapper/subscription_remove_coupon/remove_coupon_succeeds" do
-        subscription.remove_coupon(coupon_code: "45RDLWDEMNAS")
+        subscription.remove_coupon(code: "45RDLWDEMNAS")
 
         expect(WebMock).to have_requested(:delete, url_matcher)
           .with(query: {"coupon_code" => "45RDLWDEMNAS"}).once
@@ -219,7 +219,7 @@ RSpec.describe ChargifyWrapper::Subscription do
     context "when coupon code is not on the subscription" do
       it "raises ActiveResource::ResourceInvalid",
         cassette: "chargify_wrapper/subscription_remove_coupon/remove_coupon_fails" do
-        expect { subscription.remove_coupon(coupon_code: "NOT_ON_SUB") }
+        expect { subscription.remove_coupon(code: "NOT_ON_SUB") }
           .to raise_error(ActiveResource::ResourceInvalid)
       end
     end

--- a/spec/resources/subscription_spec.rb
+++ b/spec/resources/subscription_spec.rb
@@ -148,4 +148,44 @@ RSpec.describe ChargifyWrapper::Subscription do
       it { expect { reactivate_subscription }.to raise_error(ActiveResource::ResourceInvalid) }
     end
   end
+
+  describe "#apply_coupons", :vcr do
+    let(:subscription) { described_class.find(90823390) }
+    let(:url_matcher) do
+      Regexp.new(".chargify.com/subscriptions/#{subscription.id}/add_coupon\\.json\\z")
+    end
+
+    context "when codes are empty" do
+      it "raises ActiveResource::ResourceInvalid" do
+        expect { subscription.apply_coupons(codes: []) }.to raise_error(ActiveResource::ResourceInvalid)
+      end
+    end
+
+    context "when codes are valid" do
+      it "returns Net::HTTPOK" do
+        coupon = "10DAMOUNTCODEYEAR"
+
+        response = subscription.apply_coupons(codes: [coupon])
+
+        expect(response).to be_a(Net::HTTPOK)
+        payload = JSON.parse(response.body)["subscription"]
+        expect(payload["coupon_codes"]).to eq([coupon])
+        expect(payload["coupon_code"]).to eq(coupon)
+      end
+
+      it "sends the request correctly" do
+        subscription.apply_coupons(codes: %w[25RDGABSKXBZL2 45RDLWDEMNAS])
+
+        expect(WebMock).to have_requested(:post, url_matcher)
+          .with(body: { codes: %w[25RDGABSKXBZL2 45RDLWDEMNAS] }.to_json).once
+      end
+    end
+
+    context "when codes are invalid" do
+      it "raises ActiveResource::ResourceInvalid" do
+        expect { subscription.apply_coupons(codes: ["INVALID"]) }
+          .to raise_error(ActiveResource::ResourceInvalid)
+      end
+    end
+  end
 end

--- a/spec/resources/subscription_spec.rb
+++ b/spec/resources/subscription_spec.rb
@@ -167,17 +167,19 @@ RSpec.describe ChargifyWrapper::Subscription do
 
         response = subscription.apply_coupons(codes: [coupon])
 
-        expect(response).to be_a(Net::HTTPOK)
-        payload = JSON.parse(response.body)["subscription"]
-        expect(payload["coupon_codes"]).to eq([coupon])
-        expect(payload["coupon_code"]).to eq(coupon)
+        expect(response).to be_a(Net::HTTPOK).and(
+          satisfy("include coupon in subscription payload") do |r|
+            payload = JSON.parse(r.body)["subscription"]
+            payload.values_at("coupon_codes", "coupon_code") == [[coupon], coupon]
+          end
+        )
       end
 
       it "sends the request correctly" do
         subscription.apply_coupons(codes: %w[25RDGABSKXBZL2 45RDLWDEMNAS])
 
         expect(WebMock).to have_requested(:post, url_matcher)
-          .with(body: { codes: %w[25RDGABSKXBZL2 45RDLWDEMNAS] }.to_json).once
+          .with(body: {codes: %w[25RDGABSKXBZL2 45RDLWDEMNAS]}.to_json).once
       end
     end
 
@@ -200,8 +202,9 @@ RSpec.describe ChargifyWrapper::Subscription do
         cassette: "chargify_wrapper/subscription_remove_coupon/remove_coupon_succeeds" do
         response = subscription.remove_coupon(coupon_code: "45RDLWDEMNAS")
 
-        expect(response).to be_a(Net::HTTPOK)
-        expect(response.body.strip).to eq("Coupon successfully removed.")
+        expect(response).to be_a(Net::HTTPOK).and(
+          satisfy { |r| r.body.strip == "Coupon successfully removed." }
+        )
       end
 
       it "sends DELETE with coupon_code query param",


### PR DESCRIPTION
[BB-2079](https://87labs.atlassian.net/browse/BB-2079)

### Feature

The `#apply_coupons` method and the `#remove_coupon` method on `ChargifyWrapper::Subscription` links and removes coupons from subscriptions, it uncouple the coupon apply from the subscription reactivation.
It will be necessary to apply coupons without reactivate a subscription and after retrieve these linked coupons to be used in paywall pages before the deactivation.


The Chargify API endpoint involved are:
[Apply coupon](https://developers.maxio.com/http/advanced-billing-api/api-endpoints/subscriptions/apply-coupons-to-subscription)
[Remove coupon](https://developers.maxio.com/http/advanced-billing-api/api-endpoints/subscriptions/remove-coupon-from-subscription)

### Setup

Uninstall, build and install the gem
```
gem uninstall --force chargify_wrapper
gem build chargify_wrapper.gemspec --output=chargify.gem
gem install chargify_wrapper --local chargify.gem
```

### Q & A

Open an irb and configure the gem
```
require 'chargify_wrapper'

ChargifyWrapper.configure do |config|
  config.subdomain = 'your-subdomain'
  config.api_key = 'your-api-key'
  config.log_requests = true
end
```

Apply one or more coupons to a valid subscription with
```
sub = ChargifyWrapper::Subscription.find(subscription_id)
sub.apply_coupons(codes: ["COD1", "COD2"])
```
It should link the coupon codes in the Chargify subscription.
It must be validated at the Chargify site, in the subscription details of the used subscription.

Remove one coupon to a valid subscription with
```
sub = ChargifyWrapper::Subscription.find(subscription_id)
sub.remove_coupon(code: "COD1")
```
It should unlink the coupon in the Chargify subscription.
It must be validated at the Chargify site, in the subscription details of the used subscription.